### PR TITLE
feat(payment): 결제 엔티티, 값객체, 리포지토리 추가 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -253,6 +253,6 @@ $RECYCLE.BIN/
 # Windows shortcuts
 *.lnk
 
-/jacoco
+/**/jacoco
 
 postgresql/

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -11,7 +11,7 @@ repositories {
 
 dependencies {
 
-    implementation 'org.springframework.boot:spring-boot-starter-web'
+    api 'org.springframework.boot:spring-boot-starter-web'
     testImplementation platform('org.junit:junit-bom:5.10.0')
     testImplementation 'org.junit.jupiter:junit-jupiter'
 }

--- a/common/src/main/java/radiata/common/message/ExceptionMessage.java
+++ b/common/src/main/java/radiata/common/message/ExceptionMessage.java
@@ -18,6 +18,11 @@ public enum ExceptionMessage {
     NOT_FOUND(HttpStatus.NOT_FOUND, "1002", "존재하지 않는 입력값입니다."),
     // 시스템 에러 500
     SYSTEM_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "1003", "알 수 없는 에러가 발생했습니다."),
+
+    /* 결제 2000번대 */
+
+    // 잔액 부족 402
+    INSUFFICIENT_BALANCE(HttpStatus.PAYMENT_REQUIRED, "2001", "충전금이 부족합니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/service/payment/payment-core/build.gradle
+++ b/service/payment/payment-core/build.gradle
@@ -10,6 +10,22 @@ repositories {
 }
 
 dependencies {
+
+    /* module */
+
+    implementation project(':common')
+    implementation project(':database')
+
+    /* library */
+
+    // ksuid
+    implementation 'com.github.ksuid:ksuid:1.1.2'
+
+    // spring security crypto
+    implementation 'org.springframework.security:spring-security-crypto'
+
+    /* test */
+
     testImplementation platform('org.junit:junit-bom:5.10.0')
     testImplementation 'org.junit.jupiter:junit-jupiter'
 }

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/Main.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/Main.java
@@ -1,8 +1,0 @@
-package radiata.service.payment.core;
-
-public class Main {
-
-    public static void main(String[] args) {
-        System.out.println("Hello world!");
-    }
-}

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/model/entity/FirmBankingRequestHistory.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/model/entity/FirmBankingRequestHistory.java
@@ -1,0 +1,70 @@
+package radiata.service.payment.core.domain.model.entity;
+
+import com.github.ksuid.Ksuid;
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.AttributeOverrides;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
+import radiata.service.payment.core.domain.model.vo.Account;
+import radiata.service.payment.core.domain.model.vo.FirmBankingRequestStatus;
+import radiata.service.payment.core.domain.model.vo.Money;
+
+@Getter
+@Entity
+@Table(name = "r_firm_banking_request_history")
+@SQLRestriction("deleted_at IS NOT NULL")
+@Builder // 빌더 패턴은 테스트 용도로만 사용
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED) // JPA 객체는 기본 생성자를 필요로 함
+public class FirmBankingRequestHistory {
+
+    @Id
+    private String id;
+
+    @Column(nullable = false)
+    private Money amount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private FirmBankingRequestStatus status;
+
+    @Embedded
+    @AttributeOverrides({
+        @AttributeOverride(name = "bank", column = @Column(name = "from_bank")),
+        @AttributeOverride(name = "accountNumber", column = @Column(name = "from_account_umber")),
+    })
+    private Account fromAccount;
+
+    @Embedded
+    @AttributeOverrides({
+        @AttributeOverride(name = "bank", column = @Column(name = "to_bank")),
+        @AttributeOverride(name = "accountNumber", column = @Column(name = "to_account_umber")),
+    })
+    private Account toAccount;
+
+    public static FirmBankingRequestHistory of(
+        Money amount,
+        FirmBankingRequestStatus status,
+        Account fromAccount,
+        Account toAccount
+    ) {
+        return FirmBankingRequestHistory.builder()
+            .id(Ksuid.newKsuid().toString())
+            .amount(amount)
+            .status(status)
+            .fromAccount(fromAccount)
+            .toAccount(toAccount)
+            .build();
+    }
+}

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/model/entity/FirmBankingRequestHistory.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/model/entity/FirmBankingRequestHistory.java
@@ -1,6 +1,5 @@
 package radiata.service.payment.core.domain.model.entity;
 
-import com.github.ksuid.Ksuid;
 import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.AttributeOverrides;
 import jakarta.persistence.Column;
@@ -23,7 +22,7 @@ import radiata.service.payment.core.domain.model.vo.Money;
 @Getter
 @Entity
 @Table(name = "r_firm_banking_request_history")
-@SQLRestriction("deleted_at IS NOT NULL")
+@SQLRestriction("deleted_at IS NULL")
 @Builder // 빌더 패턴은 테스트 용도로만 사용
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED) // JPA 객체는 기본 생성자를 필요로 함

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/model/entity/FirmBankingRequestHistory.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/model/entity/FirmBankingRequestHistory.java
@@ -54,13 +54,14 @@ public class FirmBankingRequestHistory {
     private Account toAccount;
 
     public static FirmBankingRequestHistory of(
+        String id,
         Money amount,
         FirmBankingRequestStatus status,
         Account fromAccount,
         Account toAccount
     ) {
         return FirmBankingRequestHistory.builder()
-            .id(Ksuid.newKsuid().toString())
+            .id(id)
             .amount(amount)
             .status(status)
             .fromAccount(fromAccount)

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/model/entity/MoneyChangeHistory.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/model/entity/MoneyChangeHistory.java
@@ -1,0 +1,48 @@
+package radiata.service.payment.core.domain.model.entity;
+
+import com.github.ksuid.Ksuid;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
+import radiata.service.payment.core.domain.model.vo.Money;
+
+@Getter
+@Entity
+@Table(name = "r_money_change_history")
+@SQLRestriction("deleted_at IS NOT NULL")
+@Builder // 빌더 패턴은 테스트 용도로만 사용
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED) // JPA 객체는 기본 생성자를 필요로 함
+public class MoneyChangeHistory {
+
+    @Id
+    private String id;
+
+    @Column(nullable = false)
+    private Money amount;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "pay_user_id", nullable = false)
+    private PayUser payUser;
+
+    public static MoneyChangeHistory of(
+        Money amount,
+        PayUser payUser
+    ) {
+        return MoneyChangeHistory.builder()
+            .id(Ksuid.newKsuid().toString())
+            .amount(amount)
+            .payUser(payUser)
+            .build();
+    }
+}

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/model/entity/MoneyChangeHistory.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/model/entity/MoneyChangeHistory.java
@@ -1,6 +1,5 @@
 package radiata.service.payment.core.domain.model.entity;
 
-import com.github.ksuid.Ksuid;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -19,7 +18,7 @@ import radiata.service.payment.core.domain.model.vo.Money;
 @Getter
 @Entity
 @Table(name = "r_money_change_history")
-@SQLRestriction("deleted_at IS NOT NULL")
+@SQLRestriction("deleted_at IS NULL")
 @Builder // 빌더 패턴은 테스트 용도로만 사용
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED) // JPA 객체는 기본 생성자를 필요로 함

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/model/entity/MoneyChangeHistory.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/model/entity/MoneyChangeHistory.java
@@ -36,11 +36,12 @@ public class MoneyChangeHistory {
     private PayUser payUser;
 
     public static MoneyChangeHistory of(
+        String id,
         Money amount,
         PayUser payUser
     ) {
         return MoneyChangeHistory.builder()
-            .id(Ksuid.newKsuid().toString())
+            .id(id)
             .amount(amount)
             .payUser(payUser)
             .build();

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/model/entity/PayAccount.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/model/entity/PayAccount.java
@@ -1,6 +1,5 @@
 package radiata.service.payment.core.domain.model.entity;
 
-import com.github.ksuid.Ksuid;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -17,7 +16,7 @@ import radiata.service.payment.core.domain.model.vo.Account;
 @Getter
 @Entity
 @Table(name = "r_pay_account")
-@SQLRestriction("deleted_at IS NOT NULL")
+@SQLRestriction("deleted_at IS NULL")
 @Builder // 빌더 패턴은 테스트 용도로만 사용
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED) // JPA 객체는 기본 생성자를 필요로 함

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/model/entity/PayAccount.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/model/entity/PayAccount.java
@@ -36,11 +36,12 @@ public class PayAccount {
     private Boolean isDefault;
 
     public static PayAccount of(
+        String id,
         String nickname,
         Account account
     ) {
         return PayAccount.builder()
-            .id(Ksuid.newKsuid().toString())
+            .id(id)
             .nickname(nickname)
             .account(account)
             .isDefault(false)

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/model/entity/PayAccount.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/model/entity/PayAccount.java
@@ -1,0 +1,70 @@
+package radiata.service.payment.core.domain.model.entity;
+
+import com.github.ksuid.Ksuid;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
+import radiata.service.payment.core.domain.model.vo.Account;
+
+@Getter
+@Entity
+@Table(name = "r_pay_account")
+@SQLRestriction("deleted_at IS NOT NULL")
+@Builder // 빌더 패턴은 테스트 용도로만 사용
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED) // JPA 객체는 기본 생성자를 필요로 함
+public class PayAccount {
+
+    @Id
+    private String id;
+
+    @Column(nullable = false)
+    private String nickname;
+
+    @Embedded
+    private Account account;
+
+    @Column(nullable = false)
+    private Boolean isDefault;
+
+    public static PayAccount of(
+        String nickname,
+        Account account
+    ) {
+        return PayAccount.builder()
+            .id(Ksuid.newKsuid().toString())
+            .nickname(nickname)
+            .account(account)
+            .isDefault(false)
+            .build();
+    }
+
+    /**
+     * 주거래 계좌 등록
+     */
+    public void setDefaultAccount() {
+        this.isDefault = true;
+    }
+
+    /**
+     * 주거래 계좌 해제
+     */
+    public void unsetDefaultAccount() {
+        this.isDefault = false;
+    }
+
+    /**
+     * 계좌 별명 변경
+     */
+    public void changeNickname(String newNickname) {
+        this.nickname = newNickname;
+    }
+}

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/model/entity/PayUser.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/model/entity/PayUser.java
@@ -1,6 +1,5 @@
 package radiata.service.payment.core.domain.model.entity;
 
-import com.github.ksuid.Ksuid;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
@@ -18,7 +17,7 @@ import radiata.service.payment.core.domain.model.vo.Money;
 @Getter
 @Entity
 @Table(name = "r_pay_user")
-@SQLRestriction("deleted_at IS NOT NULL")
+@SQLRestriction("deleted_at IS NULL")
 @Builder // 빌더 패턴은 테스트 용도로만 사용
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED) // JPA 객체는 기본 생성자를 필요로 함

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/model/entity/PayUser.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/model/entity/PayUser.java
@@ -37,11 +37,12 @@ public class PayUser {
     private Money balance;
 
     public static PayUser of(
+        String id,
         String userId,
         String encodedPassword
     ) {
         return PayUser.builder()
-            .id(Ksuid.newKsuid().toString())
+            .id(id)
             .userId(userId)
             .password(encodedPassword)
             .balance(Money.of(0L))

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/model/entity/PayUser.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/model/entity/PayUser.java
@@ -1,0 +1,82 @@
+package radiata.service.payment.core.domain.model.entity;
+
+import com.github.ksuid.Ksuid;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
+import radiata.common.exception.BusinessException;
+import radiata.common.message.ExceptionMessage;
+import radiata.service.payment.core.domain.model.vo.Money;
+
+@Getter
+@Entity
+@Table(name = "r_pay_user")
+@SQLRestriction("deleted_at IS NOT NULL")
+@Builder // 빌더 패턴은 테스트 용도로만 사용
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED) // JPA 객체는 기본 생성자를 필요로 함
+public class PayUser {
+
+    @Id
+    private String id;
+
+    @Column(nullable = false)
+    private String userId;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
+    private Money balance;
+
+    public static PayUser of(
+        String userId,
+        String encodedPassword
+    ) {
+        return PayUser.builder()
+            .id(Ksuid.newKsuid().toString())
+            .userId(userId)
+            .password(encodedPassword)
+            .balance(Money.of(0L))
+            .build();
+    }
+
+    /**
+     * 비밀번호 변경
+     */
+    public void changePassword(String newEncodedPassword) {
+        this.password = newEncodedPassword;
+    }
+
+    /**
+     * 입금
+     */
+    public void deposit(Money money) {
+        this.balance = this.balance.add(money);
+    }
+
+    /**
+     * 결제 금액보다 충분한 충전금이 있는지 확인
+     */
+    public boolean isBalanceLessThan(Money paymentAmount) {
+        return this.balance.subtract(paymentAmount).isNegative();
+    }
+
+    /**
+     * 출금
+     */
+    public void withdraw(Money money) {
+        if (this.balance.subtract(money).isNegative()) {
+            throw new BusinessException(ExceptionMessage.INSUFFICIENT_BALANCE);
+        }
+
+        this.balance = this.balance.subtract(money);
+    }
+}

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/model/entity/Payment.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/model/entity/Payment.java
@@ -1,0 +1,89 @@
+package radiata.service.payment.core.domain.model.entity;
+
+import com.github.ksuid.Ksuid;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
+import radiata.service.payment.core.domain.model.vo.Money;
+import radiata.service.payment.core.domain.model.vo.PaymentStatus;
+import radiata.service.payment.core.domain.model.vo.PaymentType;
+
+@Getter
+@Entity
+@Table(name = "r_payment")
+@SQLRestriction("deleted_at IS NOT NULL")
+@Builder // 빌더 패턴은 테스트 용도로만 사용
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED) // JPA 객체는 기본 생성자를 필요로 함
+public class Payment {
+
+    @Id
+    private String id;
+
+    @Column(nullable = false)
+    private String userId;
+
+    @Column(nullable = false)
+    private String transactionId; // 각 결제 수단 별 고유한 결제 번호
+
+    @Column(nullable = false)
+    private Money amount;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private PaymentStatus status;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private PaymentType type;
+
+    private LocalDateTime approvedAt;
+
+    public static Payment of(
+        String userId,
+        String transactionId,
+        Money amount,
+        PaymentType type
+    ) {
+        return Payment.builder()
+            .id(Ksuid.newKsuid().toString())
+            .userId(userId)
+            .transactionId(transactionId)
+            .amount(amount)
+            .type(type)
+            .status(PaymentStatus.PENDING)
+            .build();
+    }
+
+    /**
+     * 결제 승인
+     */
+    public void approve() {
+        this.status = PaymentStatus.APPROVED;
+        this.approvedAt = LocalDateTime.now();
+    }
+
+    /**
+     * 결제 실패
+     */
+    public void fail() {
+        this.status = PaymentStatus.FAILED;
+    }
+
+    /**
+     * 정산
+     */
+    public void settle() {
+        this.status = PaymentStatus.SETTLED;
+    }
+}

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/model/entity/Payment.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/model/entity/Payment.java
@@ -50,13 +50,14 @@ public class Payment {
     private LocalDateTime approvedAt;
 
     public static Payment of(
+        String id,
         String userId,
         String transactionId,
         Money amount,
         PaymentType type
     ) {
         return Payment.builder()
-            .id(Ksuid.newKsuid().toString())
+            .id(id)
             .userId(userId)
             .transactionId(transactionId)
             .amount(amount)

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/model/entity/Payment.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/model/entity/Payment.java
@@ -1,6 +1,5 @@
 package radiata.service.payment.core.domain.model.entity;
 
-import com.github.ksuid.Ksuid;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -21,7 +20,7 @@ import radiata.service.payment.core.domain.model.vo.PaymentType;
 @Getter
 @Entity
 @Table(name = "r_payment")
-@SQLRestriction("deleted_at IS NOT NULL")
+@SQLRestriction("deleted_at IS NULL")
 @Builder // 빌더 패턴은 테스트 용도로만 사용
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED) // JPA 객체는 기본 생성자를 필요로 함

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/model/vo/Account.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/model/vo/Account.java
@@ -1,0 +1,36 @@
+package radiata.service.payment.core.domain.model.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Embeddable // JPA 값객체 어노테이션
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED) // JPA 엔티티, 임베디드는 기본 생성자 필수
+public class Account {
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Bank bank;
+
+    @Column(nullable = false)
+    private String accountNumber;
+
+    public static Account of(Bank bank, String accountNumber) {
+        Account account = new Account();
+        account.bank = bank;
+        account.accountNumber = accountNumber;
+        return account;
+    }
+
+    @Override
+    public String toString() {
+        return bank.getName() + " " + accountNumber;
+    }
+}

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/model/vo/Bank.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/model/vo/Bank.java
@@ -1,0 +1,78 @@
+package radiata.service.payment.core.domain.model.vo;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 금융결제원 기준 은행 및 증권사 코드
+ */
+@Getter
+@RequiredArgsConstructor
+public enum Bank {
+
+    // 은행 목록
+    KYONGNAMBANK("경남은행", "039"),
+    GWANGJUBANK("광주은행", "034"),
+    LOCALNONGHYEOP("단위농협(지역농축협)", "012"),
+    BUSANBANK("부산은행", "032"),
+    SAEMAUL("새마을금고", "045"),
+    SANLIM("산림조합", "064"),
+    SHINHAN("신한은행", "088"),
+    SHINHYEOP("신협", "048"),
+    CITI("씨티은행", "027"),
+    WOORI("우리은행", "020"),
+    POST("우체국예금보험", "071"),
+    SAVINGBANK("저축은행중앙회", "050"),
+    JEONBUKBANK("전북은행", "037"),
+    JEJUBANK("제주은행", "035"),
+    KAKAOBANK("카카오뱅크", "090"),
+    KBANK("케이뱅크", "089"),
+    TOSSBANK("토스뱅크", "092"),
+    HANA("하나은행", "081"),
+    HSBC("홍콩상하이은행", "054"),
+    IBK("IBK기업은행", "003"),
+    KOOKMIN("KB국민은행", "004"),
+    DAEGUBANK("DGB대구은행", "031"),
+    KDBBANK("KDB산업은행", "002"),
+    NONGHYEOP("NH농협은행", "011"),
+    SC("SC제일은행", "023"),
+    SUHYEOP("Sh수협은행", "007"),
+
+    // 증권사 목록
+    KYOBO_SECURITIES("교보증권", "261"),
+    DAISHIN_SECURITIES("대신증권", "267"),
+    MERITZ_SECURITIES("메리츠증권", "287"),
+    MIRAE_ASSET_SECURITIES("미래에셋증권", "238"),
+    BOOKOOK_SECURITIES("부국증권", "290"),
+    SAMSUNG_SECURITIES("삼성증권", "240"),
+    SHINYOUNG_SECURITIES("신영증권", "291"),
+    SHINHAN_INVESTMENT("신한금융투자", "278"),
+    YUANTA_SECURITIES("유안타증권", "209"),
+    EUGENE_INVESTMENT_AND_SECURITIES("유진투자증권", "280"),
+    KAKAOPAY_SECURITIES("카카오페이증권", "288"),
+    KIWOOM("키움증권", "264"),
+    TOSS_SECURITIES("토스증권", "271"),
+    KOREA_FOSS_SECURITIES("펀드온라인코리아(한국포스증권)", "294"),
+    HANA_INVESTMENT_AND_SECURITIES("하나금융투자", "270"),
+    HI_INVESTMENT_AND_SECURITIES("하이투자증권", "262"),
+    KOREA_INVESTMENT_AND_SECURITIES("한국투자증권", "243"),
+    HANHWA_INVESTMENT_AND_SECURITIES("한화투자증권", "269"),
+    HYUNDAI_MOTOR_SECURITIES("현대차증권", "263"),
+    DB_INVESTMENT_AND_SECURITIES("DB금융투자", "279"),
+    KB_SECURITIES("KB증권", "218"),
+    DAOL_INVESTMENT_AND_SECURITIES("KTB투자증권(다올투자증권)", "227"),
+    LIG_INVESTMENT_AND_SECURITIES("LIG투자증권", "292"),
+    NH_INVESTMENT_AND_SECURITIES("NH투자증권", "247"),
+    SK_SECURITIES("SK증권", "266");
+
+    private final String name;
+    private final String code;
+
+    public static Optional<Bank> findByCode(String code) {
+        return Stream.of(values())
+            .filter(bank -> bank.getCode().equals(code))
+            .findAny();
+    }
+}

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/model/vo/FirmBankingRequestStatus.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/model/vo/FirmBankingRequestStatus.java
@@ -1,0 +1,5 @@
+package radiata.service.payment.core.domain.model.vo;
+
+public enum FirmBankingRequestStatus {
+    SUCCESS, FAIL
+}

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/model/vo/Money.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/model/vo/Money.java
@@ -1,0 +1,47 @@
+package radiata.service.payment.core.domain.model.vo;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Embeddable // JPA 값객체 어노테이션
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED) // JPA 엔티티, 임베디드는 기본 생성자 필수
+public class Money {
+
+    public static final Money ZERO = new Money(0L);
+    
+    private Long amount;
+
+    public Money(long amount) {
+        this.amount = amount;
+    }
+
+    public static Money of(long amount) {
+        return new Money(amount);
+    }
+
+    public Money add(Money money) {
+        return new Money(this.amount + money.amount);
+    }
+
+    public Money subtract(final Money money) {
+        return new Money(this.amount - money.amount);
+    }
+
+    public Money multiply(int multiplier) {
+        return new Money(this.amount * multiplier);
+    }
+
+    public boolean isNegative() {
+        return amount < 0;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(amount);
+    }
+}

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/model/vo/Money.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/model/vo/Money.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 public class Money {
 
     public static final Money ZERO = new Money(0L);
-    
+
     private Long amount;
 
     public Money(long amount) {
@@ -28,7 +28,7 @@ public class Money {
         return new Money(this.amount + money.amount);
     }
 
-    public Money subtract(final Money money) {
+    public Money subtract(Money money) {
         return new Money(this.amount - money.amount);
     }
 

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/model/vo/PaymentStatus.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/model/vo/PaymentStatus.java
@@ -1,0 +1,16 @@
+package radiata.service.payment.core.domain.model.vo;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PaymentStatus {
+
+    PENDING("결제 대기"),
+    APPROVED("결제 승인"),
+    FAILED("결제 실패"),
+    SETTLED("정산 완료");
+
+    private final String title;
+}

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/model/vo/PaymentType.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/model/vo/PaymentType.java
@@ -1,0 +1,13 @@
+package radiata.service.payment.core.domain.model.vo;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PaymentType {
+    TOSS_PAYMENTS("토스페이먼츠"),
+    RADIATA_PAY("간편결제");
+
+    private final String title;
+}

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/repository/FirmBankingRequestHistoryRepository.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/repository/FirmBankingRequestHistoryRepository.java
@@ -1,0 +1,8 @@
+package radiata.service.payment.core.domain.repository;
+
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FirmBankingRequestHistoryRepository {
+
+}

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/repository/MoneyChangeHistoryRepository.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/repository/MoneyChangeHistoryRepository.java
@@ -1,0 +1,8 @@
+package radiata.service.payment.core.domain.repository;
+
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MoneyChangeHistoryRepository {
+
+}

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/repository/PayAccountRepository.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/repository/PayAccountRepository.java
@@ -1,0 +1,8 @@
+package radiata.service.payment.core.domain.repository;
+
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PayAccountRepository {
+
+}

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/repository/PayUserRepository.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/repository/PayUserRepository.java
@@ -1,0 +1,8 @@
+package radiata.service.payment.core.domain.repository;
+
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PayUserRepository {
+
+}

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/repository/PaymentRepository.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/repository/PaymentRepository.java
@@ -1,0 +1,8 @@
+package radiata.service.payment.core.domain.repository;
+
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PaymentRepository {
+
+}

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/infrastructure/FirmBankingRequestHistoryJpaRepository.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/infrastructure/FirmBankingRequestHistoryJpaRepository.java
@@ -1,0 +1,10 @@
+package radiata.service.payment.core.infrastructure;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import radiata.service.payment.core.domain.model.entity.FirmBankingRequestHistory;
+import radiata.service.payment.core.domain.repository.FirmBankingRequestHistoryRepository;
+
+public interface FirmBankingRequestHistoryJpaRepository
+    extends JpaRepository<FirmBankingRequestHistory, String>, FirmBankingRequestHistoryRepository {
+
+}

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/infrastructure/MoneyChangeHistoryJpaRepository.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/infrastructure/MoneyChangeHistoryJpaRepository.java
@@ -1,0 +1,10 @@
+package radiata.service.payment.core.infrastructure;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import radiata.service.payment.core.domain.model.entity.MoneyChangeHistory;
+import radiata.service.payment.core.domain.repository.MoneyChangeHistoryRepository;
+
+public interface MoneyChangeHistoryJpaRepository
+    extends JpaRepository<MoneyChangeHistory, String>, MoneyChangeHistoryRepository {
+
+}

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/infrastructure/PayAccountJpaRepository.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/infrastructure/PayAccountJpaRepository.java
@@ -1,0 +1,9 @@
+package radiata.service.payment.core.infrastructure;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import radiata.service.payment.core.domain.model.entity.PayAccount;
+import radiata.service.payment.core.domain.repository.PayAccountRepository;
+
+public interface PayAccountJpaRepository extends JpaRepository<PayAccount, String>, PayAccountRepository {
+
+}

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/infrastructure/PayUserJpaRepository.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/infrastructure/PayUserJpaRepository.java
@@ -1,0 +1,9 @@
+package radiata.service.payment.core.infrastructure;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import radiata.service.payment.core.domain.model.entity.PayUser;
+import radiata.service.payment.core.domain.repository.PayUserRepository;
+
+public interface PayUserJpaRepository extends JpaRepository<PayUser, String>, PayUserRepository {
+
+}

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/infrastructure/PaymentJpaRepository.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/infrastructure/PaymentJpaRepository.java
@@ -1,0 +1,9 @@
+package radiata.service.payment.core.infrastructure;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import radiata.service.payment.core.domain.model.entity.Payment;
+import radiata.service.payment.core.domain.repository.PaymentRepository;
+
+public interface PaymentJpaRepository extends JpaRepository<Payment, String>, PaymentRepository {
+
+}

--- a/service/payment/payment-core/src/test/java/radiata/service/payment/core/domain/model/entity/FirmBankingRequestHistoryTest.java
+++ b/service/payment/payment-core/src/test/java/radiata/service/payment/core/domain/model/entity/FirmBankingRequestHistoryTest.java
@@ -1,0 +1,40 @@
+package radiata.service.payment.core.domain.model.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import radiata.service.payment.core.domain.model.vo.Account;
+import radiata.service.payment.core.domain.model.vo.Bank;
+import radiata.service.payment.core.domain.model.vo.FirmBankingRequestStatus;
+import radiata.service.payment.core.domain.model.vo.Money;
+
+@DisplayName("FirmBankingRequestHistory 엔티티 테스트")
+class FirmBankingRequestHistoryTest {
+
+    FirmBankingRequestHistory firmBankingRequestHistory;
+
+    @BeforeEach
+    void setUp() {
+        firmBankingRequestHistory = FirmBankingRequestHistory.of(
+            Money.of(1000L),
+            FirmBankingRequestStatus.SUCCESS,
+            Account.of(Bank.CITI, "1234567890"),
+            Account.of(Bank.BUSANBANK, "0987654321")
+        );
+    }
+
+    @Test
+    @DisplayName("FirmBankingRequestHistory 엔티티 생성")
+    void createFirmBankingRequestHistory() {
+        // then
+        assertThat(firmBankingRequestHistory.getId()).isNotBlank();
+        assertThat(firmBankingRequestHistory.getAmount()).isEqualTo(Money.of(1000L));
+        assertThat(firmBankingRequestHistory.getStatus()).isEqualTo(FirmBankingRequestStatus.SUCCESS);
+        assertThat(firmBankingRequestHistory.getFromAccount().getBank()).isEqualTo(Bank.CITI);
+        assertThat(firmBankingRequestHistory.getFromAccount().getAccountNumber()).isEqualTo("1234567890");
+        assertThat(firmBankingRequestHistory.getToAccount().getBank()).isEqualTo(Bank.BUSANBANK);
+        assertThat(firmBankingRequestHistory.getToAccount().getAccountNumber()).isEqualTo("0987654321");
+    }
+}

--- a/service/payment/payment-core/src/test/java/radiata/service/payment/core/domain/model/entity/FirmBankingRequestHistoryTest.java
+++ b/service/payment/payment-core/src/test/java/radiata/service/payment/core/domain/model/entity/FirmBankingRequestHistoryTest.java
@@ -2,6 +2,7 @@ package radiata.service.payment.core.domain.model.entity;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.github.ksuid.Ksuid;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,6 +19,7 @@ class FirmBankingRequestHistoryTest {
     @BeforeEach
     void setUp() {
         firmBankingRequestHistory = FirmBankingRequestHistory.of(
+            Ksuid.newKsuid().toString(),
             Money.of(1000L),
             FirmBankingRequestStatus.SUCCESS,
             Account.of(Bank.CITI, "1234567890"),

--- a/service/payment/payment-core/src/test/java/radiata/service/payment/core/domain/model/entity/MoneyChangeHistoryTest.java
+++ b/service/payment/payment-core/src/test/java/radiata/service/payment/core/domain/model/entity/MoneyChangeHistoryTest.java
@@ -1,0 +1,29 @@
+package radiata.service.payment.core.domain.model.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import radiata.service.payment.core.domain.model.vo.Money;
+
+@DisplayName("MoneyChangeHistory 엔티티 테스트")
+class MoneyChangeHistoryTest {
+
+    MoneyChangeHistory moneyChangeHistory;
+
+    @BeforeEach
+    void setUp() {
+        PayUser payUser = PayUser.of("user01", "password01");
+        moneyChangeHistory = MoneyChangeHistory.of(Money.of(1000), payUser);
+    }
+
+    @Test
+    @DisplayName("MoneyChangeHistory 생성")
+    void money_change_history_create() {
+        // then
+        assertThat(moneyChangeHistory.getId()).isNotBlank();
+        assertThat(moneyChangeHistory.getAmount()).isEqualTo(Money.of(1000));
+        assertThat(moneyChangeHistory.getPayUser().getUserId()).isEqualTo("user01");
+    }
+}

--- a/service/payment/payment-core/src/test/java/radiata/service/payment/core/domain/model/entity/MoneyChangeHistoryTest.java
+++ b/service/payment/payment-core/src/test/java/radiata/service/payment/core/domain/model/entity/MoneyChangeHistoryTest.java
@@ -2,6 +2,7 @@ package radiata.service.payment.core.domain.model.entity;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.github.ksuid.Ksuid;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -14,8 +15,8 @@ class MoneyChangeHistoryTest {
 
     @BeforeEach
     void setUp() {
-        PayUser payUser = PayUser.of("user01", "password01");
-        moneyChangeHistory = MoneyChangeHistory.of(Money.of(1000), payUser);
+        PayUser payUser = PayUser.of(Ksuid.newKsuid().toString(), "user01", "password01");
+        moneyChangeHistory = MoneyChangeHistory.of(Ksuid.newKsuid().toString(), Money.of(1000), payUser);
     }
 
     @Test

--- a/service/payment/payment-core/src/test/java/radiata/service/payment/core/domain/model/entity/PayAccountTest.java
+++ b/service/payment/payment-core/src/test/java/radiata/service/payment/core/domain/model/entity/PayAccountTest.java
@@ -3,6 +3,7 @@ package radiata.service.payment.core.domain.model.entity;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.github.ksuid.Ksuid;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,7 +18,7 @@ class PayAccountTest {
     @BeforeEach
     void setUp() {
         Account account = Account.of(Bank.TOSSBANK, "1234567890");
-        payAccount = PayAccount.of("주거래계좌01", account);
+        payAccount = PayAccount.of(Ksuid.newKsuid().toString(), "주거래계좌01", account);
     }
 
     @Test

--- a/service/payment/payment-core/src/test/java/radiata/service/payment/core/domain/model/entity/PayAccountTest.java
+++ b/service/payment/payment-core/src/test/java/radiata/service/payment/core/domain/model/entity/PayAccountTest.java
@@ -1,0 +1,66 @@
+package radiata.service.payment.core.domain.model.entity;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import radiata.service.payment.core.domain.model.vo.Account;
+import radiata.service.payment.core.domain.model.vo.Bank;
+
+@DisplayName("Account 엔티티 테스트")
+class PayAccountTest {
+
+    PayAccount payAccount;
+
+    @BeforeEach
+    void setUp() {
+        Account account = Account.of(Bank.TOSSBANK, "1234567890");
+        payAccount = PayAccount.of("주거래계좌01", account);
+    }
+
+    @Test
+    @DisplayName("주거래계좌 생성")
+    void account_create() {
+        // then
+        assertThat(payAccount.getId()).isNotBlank();
+        assertThat(payAccount.getNickname()).isEqualTo("주거래계좌01");
+        assertThat(payAccount.getAccount().getBank()).isEqualTo(Bank.TOSSBANK);
+        assertThat(payAccount.getAccount().getAccountNumber()).isEqualTo("1234567890");
+        assertThat(payAccount.getIsDefault()).isFalse();
+    }
+
+    @Test
+    @DisplayName("계좌 설정")
+    void account_set_default() {
+        // when
+        payAccount.setDefaultAccount();
+
+        // then
+        assertThat(payAccount.getIsDefault()).isTrue();
+    }
+
+    @Test
+    @DisplayName("주거래계좌 해제")
+    void account_unset_default() {
+        // given
+        payAccount.setDefaultAccount();
+
+        // when
+        payAccount.unsetDefaultAccount();
+
+        // then
+        assertThat(payAccount.getIsDefault()).isFalse();
+    }
+
+    @Test
+    @DisplayName("계좌 별명 수정")
+    void account_update_nickname() {
+        // when
+        payAccount.changeNickname("주거래계좌02");
+
+        // then
+        assertThat(payAccount.getNickname()).isEqualTo("주거래계좌02");
+    }
+}

--- a/service/payment/payment-core/src/test/java/radiata/service/payment/core/domain/model/entity/PayUserTest.java
+++ b/service/payment/payment-core/src/test/java/radiata/service/payment/core/domain/model/entity/PayUserTest.java
@@ -1,0 +1,100 @@
+package radiata.service.payment.core.domain.model.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import radiata.common.exception.BusinessException;
+import radiata.common.message.ExceptionMessage;
+import radiata.service.payment.core.domain.model.vo.Money;
+
+@DisplayName("PayUser 엔티티 테스트")
+class PayUserTest {
+
+    PayUser payUser;
+
+    @BeforeEach
+    void setUp() {
+        payUser = PayUser.of("user01", "password01");
+    }
+
+    @Test
+    @DisplayName("간편결제 사용자 생성")
+    void pay_user_create() {
+        // then
+        assertThat(payUser.getId()).isNotBlank();
+        assertThat(payUser.getUserId()).isEqualTo("user01");
+        assertThat(payUser.getPassword()).isEqualTo("password01");
+    }
+
+    @Test
+    @DisplayName("비밀번호 변경")
+    void change_password() {
+        // given
+        String newPassword = "password02";
+
+        // when
+        payUser.changePassword(newPassword);
+
+        // then
+        assertThat(payUser.getPassword()).isEqualTo(newPassword);
+    }
+
+    @Test
+    @DisplayName("입금")
+    void deposit() {
+        // given
+        Money money = Money.of(1000);
+        Money beforeBalance = payUser.getBalance();
+
+        // when
+        payUser.deposit(money);
+
+        // then
+        assertThat(payUser.getBalance()).isEqualTo(beforeBalance.add(money));
+    }
+
+    @Test
+    @DisplayName("출금 - 충전금이 충분한 경우")
+    void withdraw_enough_balance() {
+        // given
+        Money money = Money.of(1000);
+        payUser.deposit(money);
+
+        // when
+        payUser.withdraw(money);
+
+        // then
+        assertThat(payUser.getBalance()).isEqualTo(Money.ZERO);
+    }
+
+    @Test
+    @DisplayName("출금 - 충전금이 부족한 경우")
+    void withdraw_not_enough_balance() {
+        // given
+        Money money = Money.of(1000);
+
+        // when & then
+        BusinessException exception = assertThrows(BusinessException.class, () -> payUser.withdraw(money));
+        
+        assertThat(exception.getMessage()).isEqualTo(ExceptionMessage.INSUFFICIENT_BALANCE.getMessage());
+        assertThat(exception.getHttpStatus()).isEqualTo(ExceptionMessage.INSUFFICIENT_BALANCE.getHttpStatus());
+        assertThat(exception.getCode()).isEqualTo(ExceptionMessage.INSUFFICIENT_BALANCE.getCode());
+    }
+
+    @Test
+    @DisplayName("결제 금액보다 충분한 충전금이 있는지 확인")
+    void is_balance_less_than() {
+        // given
+        Money money = Money.of(1000);
+        payUser.deposit(money);
+
+        // when
+        boolean result = payUser.isBalanceLessThan(Money.of(2000));
+
+        // then
+        assertThat(result).isTrue();
+    }
+}

--- a/service/payment/payment-core/src/test/java/radiata/service/payment/core/domain/model/entity/PayUserTest.java
+++ b/service/payment/payment-core/src/test/java/radiata/service/payment/core/domain/model/entity/PayUserTest.java
@@ -3,6 +3,7 @@ package radiata.service.payment.core.domain.model.entity;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.github.ksuid.Ksuid;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,7 +18,7 @@ class PayUserTest {
 
     @BeforeEach
     void setUp() {
-        payUser = PayUser.of("user01", "password01");
+        payUser = PayUser.of(Ksuid.newKsuid().toString(), "user01", "password01");
     }
 
     @Test
@@ -78,7 +79,7 @@ class PayUserTest {
 
         // when & then
         BusinessException exception = assertThrows(BusinessException.class, () -> payUser.withdraw(money));
-        
+
         assertThat(exception.getMessage()).isEqualTo(ExceptionMessage.INSUFFICIENT_BALANCE.getMessage());
         assertThat(exception.getHttpStatus()).isEqualTo(ExceptionMessage.INSUFFICIENT_BALANCE.getHttpStatus());
         assertThat(exception.getCode()).isEqualTo(ExceptionMessage.INSUFFICIENT_BALANCE.getCode());

--- a/service/payment/payment-core/src/test/java/radiata/service/payment/core/domain/model/entity/PaymentTest.java
+++ b/service/payment/payment-core/src/test/java/radiata/service/payment/core/domain/model/entity/PaymentTest.java
@@ -1,0 +1,93 @@
+package radiata.service.payment.core.domain.model.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import org.assertj.core.data.TemporalUnitWithinOffset;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import radiata.service.payment.core.domain.model.vo.Money;
+import radiata.service.payment.core.domain.model.vo.PaymentStatus;
+import radiata.service.payment.core.domain.model.vo.PaymentType;
+
+@DisplayName("Payment 엔티티 테스트")
+class PaymentTest {
+
+    Payment tossPayment;
+
+    @BeforeEach
+    void setUp() {
+        tossPayment = Payment.of(
+            "user01",
+            "transaction01",
+            Money.of(1000),
+            PaymentType.TOSS_PAYMENTS);
+    }
+
+    @Test
+    @DisplayName("토스페이먼츠 결제 생성")
+    void toss_payment_create() {
+        // then
+        assertThat(tossPayment.getId()).isNotBlank();
+        assertThat(tossPayment.getUserId()).isEqualTo("user01");
+        assertThat(tossPayment.getTransactionId()).isEqualTo("transaction01");
+        assertThat(tossPayment.getAmount()).isEqualTo(Money.of(1000));
+        assertThat(tossPayment.getStatus()).isEqualTo(PaymentStatus.PENDING);
+        assertThat(tossPayment.getType()).isEqualTo(PaymentType.TOSS_PAYMENTS);
+    }
+
+    @Test
+    @DisplayName("간편결제 생성")
+    void pay_payment_create() {
+        // given
+        Payment payPayment = Payment.of(
+            "user01",
+            "transaction01",
+            Money.of(1000),
+            PaymentType.RADIATA_PAY);
+
+        // then
+        assertThat(payPayment.getId()).isNotBlank();
+        assertThat(payPayment.getUserId()).isEqualTo("user01");
+        assertThat(payPayment.getTransactionId()).isEqualTo("transaction01");
+        assertThat(payPayment.getAmount()).isEqualTo(Money.of(1000));
+        assertThat(payPayment.getStatus()).isEqualTo(PaymentStatus.PENDING);
+        assertThat(payPayment.getType()).isEqualTo(PaymentType.RADIATA_PAY);
+    }
+
+    @Test
+    @DisplayName("결제 성공")
+    void payment_approve() {
+        // given 
+        TemporalUnitWithinOffset acceptableTimeOffset = new TemporalUnitWithinOffset(1, ChronoUnit.SECONDS);
+
+        // when
+        tossPayment.approve();
+
+        // then
+        assertThat(tossPayment.getStatus()).isEqualTo(PaymentStatus.APPROVED);
+        assertThat(tossPayment.getApprovedAt()).isCloseTo(LocalDateTime.now(), acceptableTimeOffset);
+    }
+
+    @Test
+    @DisplayName("결제 실패")
+    void payment_fail() {
+        // when
+        tossPayment.fail();
+
+        // then
+        assertThat(tossPayment.getStatus()).isEqualTo(PaymentStatus.FAILED);
+    }
+
+    @Test
+    @DisplayName("정산 성공")
+    void payment_settle() {
+        // when
+        tossPayment.settle();
+
+        // then
+        assertThat(tossPayment.getStatus()).isEqualTo(PaymentStatus.SETTLED);
+    }
+}

--- a/service/payment/payment-core/src/test/java/radiata/service/payment/core/domain/model/entity/PaymentTest.java
+++ b/service/payment/payment-core/src/test/java/radiata/service/payment/core/domain/model/entity/PaymentTest.java
@@ -2,6 +2,7 @@ package radiata.service.payment.core.domain.model.entity;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.github.ksuid.Ksuid;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import org.assertj.core.data.TemporalUnitWithinOffset;
@@ -20,6 +21,7 @@ class PaymentTest {
     @BeforeEach
     void setUp() {
         tossPayment = Payment.of(
+            Ksuid.newKsuid().toString(),
             "user01",
             "transaction01",
             Money.of(1000),
@@ -43,6 +45,7 @@ class PaymentTest {
     void pay_payment_create() {
         // given
         Payment payPayment = Payment.of(
+            Ksuid.newKsuid().toString(),
             "user01",
             "transaction01",
             Money.of(1000),

--- a/service/payment/payment-core/src/test/java/radiata/service/payment/core/domain/model/vo/AccountTest.java
+++ b/service/payment/payment-core/src/test/java/radiata/service/payment/core/domain/model/vo/AccountTest.java
@@ -1,0 +1,40 @@
+package radiata.service.payment.core.domain.model.vo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Account VO 테스트")
+class AccountTest {
+
+    @Test
+    @DisplayName("Account VO 생성")
+    void createAccount() {
+        // given
+        Bank bank = Bank.CITI;
+        String accountNumber = "1234567890";
+
+        // when
+        Account account = Account.of(bank, accountNumber);
+
+        // then
+        assertThat(account.getBank()).isEqualTo(bank);
+        assertThat(account.getAccountNumber()).isEqualTo(accountNumber);
+    }
+
+    @Test
+    @DisplayName("Account VO 문자열 변환")
+    void convertToString() {
+        // given
+        Bank bank = Bank.CITI;
+        String accountNumber = "1234567890";
+        Account account = Account.of(bank, accountNumber);
+
+        // when
+        String accountString = account.toString();
+
+        // then
+        assertThat(accountString).isEqualTo(bank.getName() + " " + accountNumber);
+    }
+}

--- a/service/payment/payment-core/src/test/java/radiata/service/payment/core/domain/model/vo/BankTest.java
+++ b/service/payment/payment-core/src/test/java/radiata/service/payment/core/domain/model/vo/BankTest.java
@@ -1,0 +1,39 @@
+package radiata.service.payment.core.domain.model.vo;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Bank VO 테스트")
+class BankTest {
+
+    @Test
+    @DisplayName("은행코드로 은행 조회")
+    void find_bank_by_code() {
+        // given
+        String code = "004";
+
+        // when
+        Optional<Bank> optionalBank = Bank.findByCode(code);
+
+        // then
+        assertThat(optionalBank).isPresent();
+        assertThat(optionalBank.get()).isEqualTo(Bank.KOOKMIN);
+    }
+
+    @Test
+    @DisplayName("은행코드로 은행 조회 - 존재하지 않는 코드")
+    void find_bank_by_code_not_exist() {
+        // given
+        String code = "999";
+
+        // when
+        Optional<Bank> optionalBank = Bank.findByCode(code);
+
+        // then
+        assertThat(optionalBank).isEmpty();
+    }
+}

--- a/service/payment/payment-core/src/test/java/radiata/service/payment/core/domain/model/vo/MoneyTest.java
+++ b/service/payment/payment-core/src/test/java/radiata/service/payment/core/domain/model/vo/MoneyTest.java
@@ -1,0 +1,88 @@
+package radiata.service.payment.core.domain.model.vo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Money 값객체 테스트")
+class MoneyTest {
+
+    @Test
+    @DisplayName("Money 생성 테스트")
+    void create() {
+        // given
+        Money money = Money.of(1000L);
+
+        // when
+        Long amount = money.getAmount();
+
+        // then
+        assertThat(amount).isEqualTo(1000L);
+    }
+
+    @Test
+    @DisplayName("Money 더하기 테스트")
+    void add() {
+        // given
+        Money money = Money.of(1000L);
+
+        // when
+        Money result = money.add(Money.of(1000L));
+
+        // then
+        assertThat(result.getAmount()).isEqualTo(2000L);
+    }
+
+    @Test
+    @DisplayName("Money 빼기 테스트")
+    void subtract() {
+        // given
+        Money money = Money.of(1000L);
+
+        // when
+        Money result = money.subtract(Money.of(1000L));
+
+        // then
+        assertThat(result.getAmount()).isEqualTo(0L);
+    }
+
+    @Test
+    @DisplayName("Money 곱하기 테스트")
+    void multiply() {
+        // given
+        Money money = Money.of(1000L);
+
+        // when
+        Money result = money.multiply(2);
+
+        // then
+        assertThat(result.getAmount()).isEqualTo(2000L);
+    }
+
+    @Test
+    @DisplayName("Money 음수 여부 테스트")
+    void isNegative() {
+        // given
+        Money money = Money.of(-1000L);
+
+        // when
+        boolean result = money.isNegative();
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("Money 문자열 변환 테스트")
+    void to_string() {
+        // given
+        Money money = Money.of(1000L);
+
+        // when
+        String result = money.toString();
+
+        // then
+        assertThat(result).isEqualTo("1000");
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

  > - close #3 

## 📝작업 내용

> 결제 도메인의 엔티티, 값객체, 리포지토리를 추가했고, 테스트 코드도 작성했습니다. 
- 엔티티
  - 결제
  - 간편결제 유저
  - 충전금 증감 내역
  - 간편결제 계좌
  - 펌뱅킹 요청 내역
- 값객체
  - 계좌
  - Money

### 스크린샷 (선택)

![스크린샷 2024-10-01 오후 5 49 56](https://github.com/user-attachments/assets/7f388bab-2c1b-458d-afac-6abfcc7aba8b)

Jacoco 기준 테스트 커버리지 100% 달성했습니다. 

## 💬리뷰 

요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>