### PR TITLE
feat(test): jacoco 테스트 커버리지 도구 추가 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [ "main" ] # main 브랜치로의 PR 올릴 시 작동
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # 아래는 /publish-unit-test-result-action 의 권한
+      checks: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Test with Gradle Wrapper
+        run: ./gradlew build
+
+      # PR에 테스트 리포트 추가
+      - name: Publish unit test results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()
+        with:
+          files: build/test-results/**/*.xml

--- a/.gitignore
+++ b/.gitignore
@@ -253,6 +253,6 @@ $RECYCLE.BIN/
 # Windows shortcuts
 *.lnk
 
-/jacoco
+/**/jacoco
 
 postgresql/

--- a/build.gradle
+++ b/build.gradle
@@ -1,69 +1,124 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.3.4' apply(false)
-	id 'io.spring.dependency-management' version '1.1.6' apply(false)
+    id 'java'
+    id 'jacoco'
+    id 'org.springframework.boot' version '3.3.4' apply(false)
+    id 'io.spring.dependency-management' version '1.1.6' apply(false)
 }
 
 allprojects {
-	group = 'radiata'
-	version = '0.0.1-SNAPSHOT'
+    group = 'radiata'
+    version = '0.0.1-SNAPSHOT'
 
-	apply plugin: 'java'
-	apply plugin: 'java-library'
+    apply plugin: 'java'
+    apply plugin: 'java-library'
+    apply plugin: 'jacoco'
 
-	repositories {
-		mavenCentral()
-	}
+    repositories {
+        mavenCentral()
+    }
 
-	test {
-		useJUnitPlatform()
-	}
+    test {
+        useJUnitPlatform()
+        finalizedBy 'jacocoTestReport' // test 끝나면 jacocoTestReport 동작
+    }
 
-	java {
-		toolchain {
-			languageVersion = JavaLanguageVersion.of(21)
-		}
-	}
+    java {
+        toolchain {
+            languageVersion = JavaLanguageVersion.of(21)
+        }
+    }
 
-	configurations {
-		compileOnly {
-			extendsFrom annotationProcessor
-		}
-	}
+    configurations {
+        compileOnly {
+            extendsFrom annotationProcessor
+        }
+    }
+    
+    // jacoco report 설정
+    jacocoTestReport {
+        reports {
+            // 리포트 타입마다 리포트 저장 경로를 설정할 수 있습니다.
+            html.destination file("jacoco/report")
+        }
+
+        // QueryDsl Q class 제외
+        def Qdomains = []
+        for (qPattern in '**/QA'..'**/QZ') {
+            Qdomains.add(qPattern + '*')
+        }
+
+        // 커버리지 보고서 제외 범위 설정
+        getClassDirectories().setFrom(
+                files(classDirectories.files.collect {
+                    fileTree(dir: it, exclude: [
+                            "**/*Application*",
+                            "**/*Config*",
+                            "**/dto",
+                            "**/*Exception*"
+                    ] + Qdomains)
+                })
+        )
+
+        // jacocoTestReport 끝나면 jacocoTestCoverageVerification 동작
+        finalizedBy 'jacocoTestCoverageVerification'
+    }
+
+    // jacoco 커버리지 검증 설정
+    jacocoTestCoverageVerification {
+
+        def Qdomains = []
+        for (qPattern in '*.QA'..'*.QZ') {
+            Qdomains.add(qPattern + '*')
+        }
+
+        violationRules {
+            rule {
+                enabled = true // 커버리지 적용 여부
+                element = 'CLASS' // 커버리지 적용 단위
+
+                excludes = [
+                        "**/*Application*",
+                        "**/*Config*",
+                        "**/dto",
+                        "**/*Exception*"
+                ] + Qdomains
+            }
+        }
+    }
 }
 
 subprojects {
 
-	if (isDirectory()) {
-		return
-	}
+    if (isDirectory()) {
+        return
+    }
 
-	apply plugin: 'org.springframework.boot'
-	apply plugin: 'io.spring.dependency-management'
-	bootJar.enabled = false
+    apply plugin: 'org.springframework.boot'
+    apply plugin: 'io.spring.dependency-management'
+    bootJar.enabled = false
 
-	dependencies {
-		/* module */
+    dependencies {
+        /* module */
 
-		/* library */
+        /* library */
 
-		// spring
-		implementation 'org.springframework.boot:spring-boot-starter'
+        // spring
+        implementation 'org.springframework.boot:spring-boot-starter'
 
-		// validation
-		implementation 'org.springframework.boot:spring-boot-starter-validation'
+        // validation
+        implementation 'org.springframework.boot:spring-boot-starter-validation'
 
-		// lombok
-		compileOnly 'org.projectlombok:lombok'
-		annotationProcessor 'org.projectlombok:lombok'
+        // lombok
+        compileOnly 'org.projectlombok:lombok'
+        annotationProcessor 'org.projectlombok:lombok'
 
-		/* test */
+        /* test */
 
-		testImplementation 'org.springframework.boot:spring-boot-starter-test'
-		testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-	}
+        testImplementation 'org.springframework.boot:spring-boot-starter-test'
+        testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    }
 }
 
 def isDirectory() {
-	return project.name == 'support' || project.name == 'service'
+    return project.name == 'support' || project.name == 'service'
 }

--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,2 @@
+# jacoco 테스트 커버리지 시, lombok이 생성한 코드는 제외
+lombok.addLombokGeneratedAnnotation = true


### PR DESCRIPTION
## #️⃣연관된 이슈

> - close #11 

## 📝작업 내용

> Jacoco 테스트 커버리지 도구를 추가했습니다.
> test 실행 시 jacoco 디렉토리가 만들어져서 내부의 index.html로 테스트 커버리지를 확인할 수 있습니다.
> Github actions CI 스크립트를 작성했습니다. 

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>