### PR TITLE
[#15] feat: 토스페이먼츠 결제 검증 API 추가 

### DIFF
--- a/common/src/main/java/radiata/common/domain/payment/dto/request/TossPaymentCreateRequestDto.java
+++ b/common/src/main/java/radiata/common/domain/payment/dto/request/TossPaymentCreateRequestDto.java
@@ -1,0 +1,10 @@
+package radiata.common.domain.payment.dto.request;
+
+public record TossPaymentCreateRequestDto(
+    String userId,
+    String orderId,
+    String paymentKey,
+    Long amount
+) {
+
+}

--- a/common/src/main/java/radiata/common/domain/payment/dto/response/TossPaymentCreateResponseDto.java
+++ b/common/src/main/java/radiata/common/domain/payment/dto/response/TossPaymentCreateResponseDto.java
@@ -1,0 +1,7 @@
+package radiata.common.domain.payment.dto.response;
+
+public record TossPaymentCreateResponseDto(
+    Boolean isPaymentSuccess
+) {
+
+}

--- a/common/src/main/java/radiata/common/message/SuccessMessage.java
+++ b/common/src/main/java/radiata/common/message/SuccessMessage.java
@@ -9,6 +9,9 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum SuccessMessage {
 
+    /* 공통 */
+    OK(HttpStatus.OK, "0", "정상 처리 되었습니다."),
+
     ;
 
     private final HttpStatus httpStatus;

--- a/service/payment/payment-api/build.gradle
+++ b/service/payment/payment-api/build.gradle
@@ -10,6 +10,17 @@ repositories {
 }
 
 dependencies {
+
+    /* module */
+
+    implementation project(':common')
+    api project(':service:payment:payment-core')
+
+    /* library */
+
+
+    /* test */
+
     testImplementation platform('org.junit:junit-bom:5.10.0')
     testImplementation 'org.junit.jupiter:junit-jupiter'
 }

--- a/service/payment/payment-api/src/main/java/radiata/service/payment/api/Main.java
+++ b/service/payment/payment-api/src/main/java/radiata/service/payment/api/Main.java
@@ -1,8 +1,0 @@
-package radiata.service.payment.api;
-
-public class Main {
-
-    public static void main(String[] args) {
-        System.out.println("Hello world!");
-    }
-}

--- a/service/payment/payment-api/src/main/java/radiata/service/payment/api/PaymentApplication.java
+++ b/service/payment/payment-api/src/main/java/radiata/service/payment/api/PaymentApplication.java
@@ -1,0 +1,12 @@
+package radiata.service.payment.api;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication(scanBasePackages = {"radiata.service.payment"})
+public class PaymentApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(PaymentApplication.class, args);
+    }
+}

--- a/service/payment/payment-api/src/main/java/radiata/service/payment/api/presentation/PaymentController.java
+++ b/service/payment/payment-api/src/main/java/radiata/service/payment/api/presentation/PaymentController.java
@@ -1,0 +1,31 @@
+package radiata.service.payment.api.presentation;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import radiata.common.domain.payment.dto.request.TossPaymentCreateRequestDto;
+import radiata.common.domain.payment.dto.response.TossPaymentCreateResponseDto;
+import radiata.common.response.SuccessResponse;
+import radiata.service.payment.core.service.TossPaymentService;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/payments")
+public class PaymentController {
+
+    private final TossPaymentService tossPaymentService;
+
+    @PostMapping("/toss")
+    public SuccessResponse<TossPaymentCreateResponseDto> requestTossPayment(
+        @RequestBody TossPaymentCreateRequestDto request
+    ) {
+        boolean isPaymentSuccess = tossPaymentService.requestTossPayment(request);
+        TossPaymentCreateResponseDto response = new TossPaymentCreateResponseDto(isPaymentSuccess);
+
+        return SuccessResponse.success("결제 성공", response);
+    }
+}

--- a/service/payment/payment-api/src/main/java/radiata/service/payment/api/presentation/PaymentController.java
+++ b/service/payment/payment-api/src/main/java/radiata/service/payment/api/presentation/PaymentController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import radiata.common.domain.payment.dto.request.TossPaymentCreateRequestDto;
 import radiata.common.domain.payment.dto.response.TossPaymentCreateResponseDto;
+import radiata.common.message.SuccessMessage;
 import radiata.common.response.SuccessResponse;
 import radiata.service.payment.core.service.TossPaymentService;
 
@@ -26,6 +27,6 @@ public class PaymentController {
         boolean isPaymentSuccess = tossPaymentService.requestTossPayment(request);
         TossPaymentCreateResponseDto response = new TossPaymentCreateResponseDto(isPaymentSuccess);
 
-        return SuccessResponse.success("결제 성공", response);
+        return SuccessResponse.success(SuccessMessage.OK.getMessage(), response);
     }
 }

--- a/service/payment/payment-api/src/main/java/radiata/service/payment/api/presentation/PaymentController.java
+++ b/service/payment/payment-api/src/main/java/radiata/service/payment/api/presentation/PaymentController.java
@@ -24,9 +24,6 @@ public class PaymentController {
     public SuccessResponse<TossPaymentCreateResponseDto> requestTossPayment(
         @RequestBody TossPaymentCreateRequestDto request
     ) {
-        boolean isPaymentSuccess = tossPaymentService.requestTossPayment(request);
-        TossPaymentCreateResponseDto response = new TossPaymentCreateResponseDto(isPaymentSuccess);
-
-        return SuccessResponse.success(SuccessMessage.OK.getMessage(), response);
+        return SuccessResponse.success(SuccessMessage.OK.getMessage(), tossPaymentService.requestTossPayment(request));
     }
 }

--- a/service/payment/payment-api/src/main/resources/application-dev.yml
+++ b/service/payment/payment-api/src/main/resources/application-dev.yml
@@ -1,0 +1,3 @@
+toss-payment:
+  confirm-url: https://api.tosspayments.com/v1/payments/confirm
+  test-secret-key: test_gsk_docs_OaPz8L5KdmQXkzRz3y47BMw6

--- a/service/payment/payment-api/src/main/resources/application.yml
+++ b/service/payment/payment-api/src/main/resources/application.yml
@@ -1,0 +1,5 @@
+spring:
+  config:
+    import: classpath:application-database.yml # database 속성 가져오기용
+  profiles:
+    default: dev

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/ComponentScanConfiguration.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/ComponentScanConfiguration.java
@@ -1,0 +1,13 @@
+package radiata.service.payment.core;
+
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * JpaRepository 빈 조회를 위한 ComponentScan 설정
+ */
+@EnableAutoConfiguration
+@Configuration
+public class ComponentScanConfiguration {
+
+}

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/config/RestTemplateConfig.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/config/RestTemplateConfig.java
@@ -1,0 +1,22 @@
+package radiata.service.payment.core.config;
+
+import java.time.Duration;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder restTemplateBuilder) {
+
+        return restTemplateBuilder
+            // RestTemplate 으로 외부 API 호출 시 일정 시간이 지나도 응답이 없을 때
+            // 무한 대기 상태 방지를 위해 강제 종료 설정
+            .setConnectTimeout(Duration.ofSeconds(5)) // 5초
+            .setReadTimeout(Duration.ofSeconds(5)) // 5초
+            .build();
+    }
+}

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/model/entity/Payment.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/model/entity/Payment.java
@@ -13,6 +13,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLRestriction;
+import radiata.database.model.BaseEntity;
 import radiata.service.payment.core.domain.model.vo.Money;
 import radiata.service.payment.core.domain.model.vo.PaymentStatus;
 import radiata.service.payment.core.domain.model.vo.PaymentType;
@@ -24,7 +25,7 @@ import radiata.service.payment.core.domain.model.vo.PaymentType;
 @Builder // 빌더 패턴은 테스트 용도로만 사용
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED) // JPA 객체는 기본 생성자를 필요로 함
-public class Payment {
+public class Payment extends BaseEntity {
 
     @Id
     private String id;

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/model/entity/Payment.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/model/entity/Payment.java
@@ -49,6 +49,8 @@ public class Payment extends BaseEntity {
 
     private LocalDateTime approvedAt;
 
+    private LocalDateTime settledAt;
+
     public static Payment of(
         String id,
         String userId,
@@ -86,5 +88,6 @@ public class Payment extends BaseEntity {
      */
     public void settle() {
         this.status = PaymentStatus.SETTLED;
+        this.settledAt = LocalDateTime.now();
     }
 }

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/repository/PaymentRepository.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/repository/PaymentRepository.java
@@ -1,8 +1,10 @@
 package radiata.service.payment.core.domain.repository;
 
 import org.springframework.stereotype.Repository;
+import radiata.service.payment.core.domain.model.entity.Payment;
 
 @Repository
 public interface PaymentRepository {
 
+    Payment save(Payment payment);
 }

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/implementation/PaymentRequester.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/implementation/PaymentRequester.java
@@ -12,6 +12,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
 import radiata.common.annotation.Implementation;
 import radiata.service.payment.core.domain.model.entity.Payment;
@@ -30,6 +31,7 @@ public class PaymentRequester {
     @Value("${toss-payment.confirm-url}")
     private String TOSS_PAYMENT_CONFIRM_API_URL;
 
+    @Transactional
     public void requestTossPayment(Payment payment, String orderId) {
 
         RequestEntity<TossPaymentConfirmRequestDto> requestEntity = createRequestEntity(orderId, payment);

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/implementation/PaymentRequester.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/implementation/PaymentRequester.java
@@ -50,8 +50,6 @@ public class PaymentRequester {
 
     private RequestEntity<TossPaymentConfirmRequestDto> createRequestEntity(String orderId, Payment payment) {
 
-        HttpHeaders headers = createHeaders();
-
         TossPaymentConfirmRequestDto body = new TossPaymentConfirmRequestDto(
             orderId,
             payment.getTransactionId(),
@@ -59,7 +57,7 @@ public class PaymentRequester {
 
         return RequestEntity
             .post(URI.create(TOSS_PAYMENT_CONFIRM_API_URL))
-            .headers(headers)
+            .headers(createHeaders())
             .body(body);
     }
 

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/implementation/PaymentRequester.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/implementation/PaymentRequester.java
@@ -57,11 +57,11 @@ public class PaymentRequester {
 
         return RequestEntity
             .post(URI.create(TOSS_PAYMENT_CONFIRM_API_URL))
-            .headers(createHeaders())
+            .headers(createJsonTypeHeaders())
             .body(body);
     }
 
-    private HttpHeaders createHeaders() {
+    private HttpHeaders createJsonTypeHeaders() {
         HttpHeaders httpHeaders = new HttpHeaders();
 
         httpHeaders.setContentType(MediaType.APPLICATION_JSON);

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/implementation/PaymentRequester.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/implementation/PaymentRequester.java
@@ -1,0 +1,78 @@
+package radiata.service.payment.core.implementation;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.net.URI;
+import java.util.Base64;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.RequestEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+import radiata.common.annotation.Implementation;
+import radiata.service.payment.core.domain.model.entity.Payment;
+import radiata.service.payment.core.service.request.TossPaymentConfirmRequestDto;
+
+@Slf4j
+@Implementation
+@RequiredArgsConstructor
+public class PaymentRequester {
+
+    private final RestTemplate restTemplate;
+
+    @Value("${toss-payment.test-secret-key}")
+    private String TOSS_PAYMENT_TEST_SECRET_KEY;
+
+    @Value("${toss-payment.confirm-url}")
+    private String TOSS_PAYMENT_CONFIRM_API_URL;
+
+    public void requestTossPayment(Payment payment, String orderId) {
+
+        RequestEntity<TossPaymentConfirmRequestDto> requestEntity = createRequestEntity(orderId, payment);
+        ResponseEntity<String> response = restTemplate.exchange(requestEntity, String.class);
+
+        if (isPaymentSuccess(response)) {
+            payment.approve();
+        } else {
+            payment.fail();
+        }
+    }
+
+    private boolean isPaymentSuccess(ResponseEntity<String> response) {
+        return response.getStatusCode().is2xxSuccessful();
+    }
+
+    private RequestEntity<TossPaymentConfirmRequestDto> createRequestEntity(String orderId, Payment payment) {
+
+        HttpHeaders headers = createHeaders();
+
+        TossPaymentConfirmRequestDto body = new TossPaymentConfirmRequestDto(
+            orderId,
+            payment.getTransactionId(),
+            payment.getAmount().getAmount());
+
+        return RequestEntity
+            .post(URI.create(TOSS_PAYMENT_CONFIRM_API_URL))
+            .headers(headers)
+            .body(body);
+    }
+
+    private HttpHeaders createHeaders() {
+        HttpHeaders httpHeaders = new HttpHeaders();
+
+        httpHeaders.setContentType(MediaType.APPLICATION_JSON);
+        httpHeaders.setAccept(List.of(MediaType.APPLICATION_JSON));
+        httpHeaders.setBasicAuth(createBasicAuth());
+
+        return httpHeaders;
+    }
+
+    private String createBasicAuth() {
+        String secretKeyWithPassword = TOSS_PAYMENT_TEST_SECRET_KEY + ":";
+        return new String(Base64.getEncoder().encode(secretKeyWithPassword.getBytes(UTF_8)));
+    }
+}

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/implementation/PaymentSaver.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/implementation/PaymentSaver.java
@@ -3,6 +3,7 @@ package radiata.service.payment.core.implementation;
 import com.github.ksuid.KsuidGenerator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
 import radiata.common.annotation.Implementation;
 import radiata.service.payment.core.domain.model.entity.Payment;
 import radiata.service.payment.core.domain.model.vo.Money;
@@ -16,6 +17,7 @@ public class PaymentSaver {
 
     private final PaymentRepository paymentRepository;
 
+    @Transactional
     public Payment createTossPayment(String userId, String paymentKey, Long amount) {
         Payment payment = Payment.of(
             KsuidGenerator.generate(),

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/implementation/PaymentSaver.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/implementation/PaymentSaver.java
@@ -1,0 +1,29 @@
+package radiata.service.payment.core.implementation;
+
+import com.github.ksuid.KsuidGenerator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import radiata.common.annotation.Implementation;
+import radiata.service.payment.core.domain.model.entity.Payment;
+import radiata.service.payment.core.domain.model.vo.Money;
+import radiata.service.payment.core.domain.model.vo.PaymentType;
+import radiata.service.payment.core.domain.repository.PaymentRepository;
+
+@Slf4j
+@Implementation
+@RequiredArgsConstructor
+public class PaymentSaver {
+
+    private final PaymentRepository paymentRepository;
+
+    public Payment createTossPayment(String userId, String paymentKey, Long amount) {
+        Payment payment = Payment.of(
+            KsuidGenerator.generate(),
+            userId,
+            paymentKey,
+            Money.of(amount),
+            PaymentType.TOSS_PAYMENTS);
+
+        return paymentRepository.save(payment);
+    }
+}

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/service/TossPaymentService.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/service/TossPaymentService.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import radiata.common.domain.payment.dto.request.TossPaymentCreateRequestDto;
+import radiata.common.domain.payment.dto.response.TossPaymentCreateResponseDto;
 import radiata.service.payment.core.domain.model.entity.Payment;
 import radiata.service.payment.core.domain.model.vo.PaymentStatus;
 import radiata.service.payment.core.implementation.PaymentRequester;
@@ -19,12 +20,12 @@ public class TossPaymentService {
     private final PaymentRequester paymentRequester;
 
     @Transactional
-    public boolean requestTossPayment(TossPaymentCreateRequestDto request) {
+    public TossPaymentCreateResponseDto requestTossPayment(TossPaymentCreateRequestDto request) {
         // 결제 생성
         Payment payment = paymentSaver.createTossPayment(request.userId(), request.paymentKey(), request.amount());
         // 토스 결제 요청
         paymentRequester.requestTossPayment(payment, request.orderId());
 
-        return payment.getStatus().equals(PaymentStatus.APPROVED);
+        return new TossPaymentCreateResponseDto(payment.getStatus().equals(PaymentStatus.APPROVED));
     }
 }

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/service/TossPaymentService.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/service/TossPaymentService.java
@@ -1,0 +1,30 @@
+package radiata.service.payment.core.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import radiata.common.domain.payment.dto.request.TossPaymentCreateRequestDto;
+import radiata.service.payment.core.domain.model.entity.Payment;
+import radiata.service.payment.core.domain.model.vo.PaymentStatus;
+import radiata.service.payment.core.implementation.PaymentRequester;
+import radiata.service.payment.core.implementation.PaymentSaver;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TossPaymentService {
+
+    private final PaymentSaver paymentSaver;
+    private final PaymentRequester paymentRequester;
+
+    @Transactional
+    public boolean requestTossPayment(TossPaymentCreateRequestDto request) {
+        // 결제 생성
+        Payment payment = paymentSaver.createTossPayment(request.userId(), request.paymentKey(), request.amount());
+        // 토스 결제 요청
+        paymentRequester.requestTossPayment(payment, request.orderId());
+
+        return payment.getStatus().equals(PaymentStatus.APPROVED);
+    }
+}

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/service/request/TossPaymentConfirmRequestDto.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/service/request/TossPaymentConfirmRequestDto.java
@@ -1,0 +1,9 @@
+package radiata.service.payment.core.service.request;
+
+public record TossPaymentConfirmRequestDto(
+    String orderId,
+    String paymentKey,
+    Long amount
+) {
+
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> - close #15 

## 📝작업 내용

> 토스페이먼츠 결제 검증 API를 만들었습니다. 프론트 -> 주문 으로 검증 요청 시, 주문 -> 결제 검증 요청할 때 쓰입니다. 

### 스크린샷 (선택)
<img width="1180" alt="스크린샷 2024-10-02 오후 9 17 00" src="https://github.com/user-attachments/assets/7c1d8cef-fafc-4ae2-ad71-34c5d2791651">

결제 성공 사진입니다!

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> 각 객체가 적절한 디렉토리에 위치하는지, API 응답은 적절한지 궁금합니다. 