### PR TITLE
[#28] feat(payment): 결제 확인 API 응답 수정, 테스트 코드 작성 

### DIFF
--- a/common/src/main/java/radiata/common/domain/payment/dto/response/TossPaymentCreateResponseDto.java
+++ b/common/src/main/java/radiata/common/domain/payment/dto/response/TossPaymentCreateResponseDto.java
@@ -1,7 +1,8 @@
 package radiata.common.domain.payment.dto.response;
 
 public record TossPaymentCreateResponseDto(
-    Boolean isPaymentSuccess
+    Boolean isPaymentSuccess,
+    String paymentId
 ) {
 
 }

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/service/TossPaymentService.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/service/TossPaymentService.java
@@ -26,6 +26,6 @@ public class TossPaymentService {
         // 토스 결제 요청
         paymentRequester.requestTossPayment(payment, request.orderId());
 
-        return new TossPaymentCreateResponseDto(payment.getStatus().equals(PaymentStatus.APPROVED));
+        return new TossPaymentCreateResponseDto(payment.getStatus().equals(PaymentStatus.APPROVED), payment.getId());
     }
 }

--- a/service/payment/payment-core/src/test/java/radiata/service/payment/core/implementation/PaymentRequesterTest.java
+++ b/service/payment/payment-core/src/test/java/radiata/service/payment/core/implementation/PaymentRequesterTest.java
@@ -1,0 +1,99 @@
+package radiata.service.payment.core.implementation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.eq;
+import static org.mockito.BDDMockito.given;
+
+import com.github.ksuid.KsuidGenerator;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.RequestEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.RestTemplate;
+import radiata.service.payment.core.domain.model.entity.Payment;
+import radiata.service.payment.core.domain.model.vo.Money;
+import radiata.service.payment.core.domain.model.vo.PaymentStatus;
+import radiata.service.payment.core.domain.model.vo.PaymentType;
+
+@DisplayName("PaymentRequester 테스트")
+@ExtendWith(MockitoExtension.class)
+class PaymentRequesterTest {
+
+    @InjectMocks
+    private PaymentRequester paymentRequester;
+
+    @Mock
+    private RestTemplate restTemplate;
+
+    @Test
+    @DisplayName("토스 결제 요청 성공 테스트")
+    void request_toss_payment_success() {
+        // given
+        String orderId = KsuidGenerator.generate();
+        Payment payment = Payment.of(
+            KsuidGenerator.generate(),
+            KsuidGenerator.generate(),
+            "paymentKey-01",
+            Money.of(1000L),
+            PaymentType.TOSS_PAYMENTS
+        );
+
+        ReflectionTestUtils.setField(
+            paymentRequester,
+            "TOSS_PAYMENT_CONFIRM_API_URL",
+            "https://api.tosspayments.com/v1/payments/confirm");
+
+        ReflectionTestUtils.setField(
+            paymentRequester,
+            "TOSS_PAYMENT_TEST_SECRET_KEY",
+            " test_gsk_docs_OaPz8L5KdmQXkzRz3y47BMw6");
+
+        given(restTemplate.exchange(any(RequestEntity.class), eq(String.class)))
+            .willReturn(ResponseEntity.ok().build());
+
+        // when
+        paymentRequester.requestTossPayment(payment, orderId);
+
+        // then
+        assertThat(payment.getStatus()).isEqualTo(PaymentStatus.APPROVED);
+    }
+
+    @Test
+    @DisplayName("토스 결제 요청 실패 테스트")
+    void request_toss_payment_fail() {
+        // given
+        String orderId = KsuidGenerator.generate();
+        Payment payment = Payment.of(
+            KsuidGenerator.generate(),
+            KsuidGenerator.generate(),
+            "paymentKey-01",
+            Money.of(1000L),
+            PaymentType.TOSS_PAYMENTS
+        );
+
+        ReflectionTestUtils.setField(
+            paymentRequester,
+            "TOSS_PAYMENT_CONFIRM_API_URL",
+            "https://api.tosspayments.com/v1/payments/confirm");
+
+        ReflectionTestUtils.setField(
+            paymentRequester,
+            "TOSS_PAYMENT_TEST_SECRET_KEY",
+            " test_gsk_docs_OaPz8L5KdmQXkzRz3y47BMw6");
+
+        given(restTemplate.exchange(any(RequestEntity.class), eq(String.class)))
+            .willReturn(ResponseEntity.badRequest().build());
+
+        // when
+        paymentRequester.requestTossPayment(payment, orderId);
+
+        // then
+        assertThat(payment.getStatus()).isEqualTo(PaymentStatus.FAILED);
+    }
+}

--- a/service/payment/payment-core/src/test/java/radiata/service/payment/core/implementation/PaymentSaverTest.java
+++ b/service/payment/payment-core/src/test/java/radiata/service/payment/core/implementation/PaymentSaverTest.java
@@ -1,0 +1,54 @@
+package radiata.service.payment.core.implementation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.github.ksuid.KsuidGenerator;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import radiata.service.payment.core.domain.model.entity.Payment;
+import radiata.service.payment.core.domain.model.vo.Money;
+import radiata.service.payment.core.domain.model.vo.PaymentType;
+import radiata.service.payment.core.domain.repository.PaymentRepository;
+
+@DisplayName("PaymentSaver 테스트")
+@ExtendWith(MockitoExtension.class)
+class PaymentSaverTest {
+
+    @InjectMocks
+    private PaymentSaver paymentSaver;
+
+    @Mock
+    private PaymentRepository paymentRepository;
+
+    @Test
+    @DisplayName("토스 결제 생성 테스트")
+    void createTossPayment() {
+        // given
+        String userId = KsuidGenerator.generate();
+        String paymentKey = "paymentKey-01"; // 토스페이먼츠 고유 결제 키
+        long amount = 1000L;
+        given(paymentRepository.save(any(Payment.class))).willReturn(Payment.of(
+            KsuidGenerator.generate(),
+            userId,
+            paymentKey,
+            Money.of(amount),
+            PaymentType.TOSS_PAYMENTS
+        ));
+
+        // when
+        Payment savedPayment = paymentSaver.createTossPayment(userId, paymentKey, amount);
+
+        // then
+        assertThat(savedPayment).isNotNull();
+        assertThat(savedPayment.getUserId()).isEqualTo(userId);
+        assertThat(savedPayment.getTransactionId()).isEqualTo(paymentKey);
+        assertThat(savedPayment.getAmount().getAmount()).isEqualTo(amount);
+        assertThat(savedPayment.getType()).isEqualTo(PaymentType.TOSS_PAYMENTS);
+    }
+}

--- a/service/payment/payment-core/src/test/java/radiata/service/payment/core/service/TossPaymentServiceTest.java
+++ b/service/payment/payment-core/src/test/java/radiata/service/payment/core/service/TossPaymentServiceTest.java
@@ -1,0 +1,110 @@
+package radiata.service.payment.core.service;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
+
+import com.github.ksuid.KsuidGenerator;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import radiata.common.domain.payment.dto.request.TossPaymentCreateRequestDto;
+import radiata.common.domain.payment.dto.response.TossPaymentCreateResponseDto;
+import radiata.service.payment.core.domain.model.entity.Payment;
+import radiata.service.payment.core.implementation.PaymentRequester;
+import radiata.service.payment.core.implementation.PaymentSaver;
+
+@DisplayName("TossPaymentService 테스트")
+@ExtendWith(MockitoExtension.class)
+class TossPaymentServiceTest {
+
+    @InjectMocks
+    private TossPaymentService tossPaymentService;
+
+    @Mock
+    private PaymentSaver paymentSaver;
+
+    @Mock
+    private PaymentRequester paymentRequester;
+
+    @Test
+    @DisplayName("토스 결제 요청 성공 테스트")
+    void request_toss_payment_success() {
+        // given
+        String userId = KsuidGenerator.generate();
+        String orderId = KsuidGenerator.generate();
+        String paymentId = KsuidGenerator.generate();
+        String paymentKey = "tosspaymentkey-01";
+        long amount = 1000L;
+
+        Payment payment = spy(Payment.class);
+        TossPaymentCreateRequestDto requestDto = new TossPaymentCreateRequestDto(userId, orderId, paymentKey, amount);
+
+        given(paymentSaver.createTossPayment(anyString(), eq(paymentKey), anyLong())).will(
+            invocation -> {
+                ReflectionTestUtils.setField(payment, "id", paymentId);
+                ReflectionTestUtils.setField(payment, "transactionId", paymentKey);
+                return payment;
+            });
+
+        doAnswer(invocation -> {
+            Payment paymentArgument = invocation.getArgument(0);
+            paymentArgument.approve();
+            ReflectionTestUtils.setField(paymentArgument, "id", paymentId);
+            return null;
+        }).when(paymentRequester).requestTossPayment(eq(payment), anyString());
+
+        // when
+        TossPaymentCreateResponseDto responseDto = tossPaymentService.requestTossPayment(requestDto);
+
+        // then
+        assertThat(responseDto).isNotNull();
+        assertThat(responseDto.isPaymentSuccess()).isTrue();
+        assertThat(responseDto.paymentId()).isEqualTo(paymentId);
+    }
+
+    @Test
+    @DisplayName("토스 결제 요청 실패 테스트")
+    void request_toss_payment_fail() {
+        // given
+        String userId = KsuidGenerator.generate();
+        String orderId = KsuidGenerator.generate();
+        String paymentId = KsuidGenerator.generate();
+        String paymentKey = "tosspaymentkey-01";
+        long amount = 1000L;
+
+        Payment payment = spy(Payment.class);
+        TossPaymentCreateRequestDto requestDto = new TossPaymentCreateRequestDto(userId, orderId, paymentKey, amount);
+
+        given(paymentSaver.createTossPayment(anyString(), eq(paymentKey), anyLong())).will(
+            invocation -> {
+                ReflectionTestUtils.setField(payment, "id", paymentId);
+                ReflectionTestUtils.setField(payment, "transactionId", paymentKey);
+                return payment;
+            });
+
+        doAnswer(invocation -> {
+            Payment paymentArgument = invocation.getArgument(0);
+            paymentArgument.fail();
+            ReflectionTestUtils.setField(paymentArgument, "id", paymentId);
+            return null;
+        }).when(paymentRequester).requestTossPayment(eq(payment), anyString());
+
+        // when
+        TossPaymentCreateResponseDto responseDto = tossPaymentService.requestTossPayment(requestDto);
+
+        // then
+        assertThat(responseDto).isNotNull();
+        assertThat(responseDto.isPaymentSuccess()).isFalse();
+        assertThat(responseDto.paymentId()).isEqualTo(paymentId);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> - close #28 

## 📝작업 내용
- 결제 확인 API 응답에 결제 id 
- 결제 service, implementation 계층 테스트 코드 작성 

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)
![스크린샷 2024-10-07 오후 5 32 53](https://github.com/user-attachments/assets/0cdfae8c-9080-4f8d-960d-b3b1affe1cf8)

자코코 테스트 커버리지 기준 payment-core 100% 달성했습니다!

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>