### PR TITLE
[#37] feat(database): 멀티 datasource 추가 

### DIFF
--- a/database/build.gradle
+++ b/database/build.gradle
@@ -11,13 +11,20 @@ repositories {
 
 dependencies {
 
-//    api 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
-//    api "com.querydsl:querydsl-apt:5.0.0:jakarta"
-//    api "jakarta.annotation:jakarta.annotation-api"
-//    api "jakarta.persistence:jakarta.persistence-api"
+    /* module */
+
+    /* library */
+
+    // jpa
     api 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+    // redis
     api 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    // postgresql
     api 'org.postgresql:postgresql'
+
+    /* test */
 }
 
 test {

--- a/database/src/main/java/radiata/database/DatabaseModuleConfig.java
+++ b/database/src/main/java/radiata/database/DatabaseModuleConfig.java
@@ -1,0 +1,14 @@
+package radiata.database;
+
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ComponentScan
+@EnableAutoConfiguration
+@ConfigurationPropertiesScan
+public class DatabaseModuleConfig {
+
+}

--- a/database/src/main/java/radiata/database/configuration/DataSourceConfig.java
+++ b/database/src/main/java/radiata/database/configuration/DataSourceConfig.java
@@ -45,6 +45,8 @@ public class DataSourceConfig {
             .password(batchDataSourceProperty.password())
             .build();
 
+        dataSource.setMaximumPoolSize(1);
+
         return new LazyConnectionDataSourceProxy(dataSource); // 트랜잭션 진입 하더라도 커넥션 가져오지 않음
     }
 

--- a/database/src/main/java/radiata/database/configuration/DataSourceConfig.java
+++ b/database/src/main/java/radiata/database/configuration/DataSourceConfig.java
@@ -21,6 +21,9 @@ public class DataSourceConfig {
     private final MainDataSourceProperty mainDataSourceProperty;
     private final BatchDataSourceProperty batchDataSourceProperty;
 
+    /**
+     * 메인 DB 데이터소스
+     */
     @Bean("dataSource")
     @Primary
     public DataSource mainDataSource() {
@@ -35,6 +38,9 @@ public class DataSourceConfig {
         return new LazyConnectionDataSourceProxy(dataSource); // 트랜잭션 진입 하더라도 커넥션 가져오지 않음
     }
 
+    /**
+     * 배치 메타데이터 저장용 데이터소스
+     */
     @Bean("batchDataSource")
     public DataSource batchDataSource() {
         HikariDataSource dataSource = DataSourceBuilder.create()

--- a/database/src/main/java/radiata/database/configuration/DataSourceConfig.java
+++ b/database/src/main/java/radiata/database/configuration/DataSourceConfig.java
@@ -1,0 +1,57 @@
+package radiata.database.configuration;
+
+import com.zaxxer.hikari.HikariDataSource;
+import jakarta.persistence.EntityManagerFactory;
+import javax.sql.DataSource;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.transaction.PlatformTransactionManager;
+import radiata.database.property.BatchDataSourceProperty;
+import radiata.database.property.MainDataSourceProperty;
+
+@Configuration
+@RequiredArgsConstructor
+public class DataSourceConfig {
+
+    private final MainDataSourceProperty mainDataSourceProperty;
+    private final BatchDataSourceProperty batchDataSourceProperty;
+
+    @Bean("dataSource")
+    @Primary
+    public DataSource mainDataSource() {
+        HikariDataSource dataSource = DataSourceBuilder.create()
+            .type(HikariDataSource.class)
+            .driverClassName(mainDataSourceProperty.driverClassName())
+            .url(mainDataSourceProperty.url())
+            .username(mainDataSourceProperty.username())
+            .password(mainDataSourceProperty.password())
+            .build();
+
+        return new LazyConnectionDataSourceProxy(dataSource); // 트랜잭션 진입 하더라도 커넥션 가져오지 않음
+    }
+
+    @Bean("batchDataSource")
+    public DataSource batchDataSource() {
+        HikariDataSource dataSource = DataSourceBuilder.create()
+            .type(HikariDataSource.class)
+            .driverClassName(batchDataSourceProperty.driverClassName())
+            .url(batchDataSourceProperty.url())
+            .username(batchDataSourceProperty.username())
+            .password(batchDataSourceProperty.password())
+            .build();
+
+        return new LazyConnectionDataSourceProxy(dataSource); // 트랜잭션 진입 하더라도 커넥션 가져오지 않음
+    }
+
+    @Bean
+    public PlatformTransactionManager transactionManager(EntityManagerFactory entityManagerFactory) {
+        JpaTransactionManager jpaTransactionManager = new JpaTransactionManager();
+        jpaTransactionManager.setEntityManagerFactory(entityManagerFactory);
+        return jpaTransactionManager;
+    }
+}

--- a/database/src/main/java/radiata/database/property/BatchDataSourceProperty.java
+++ b/database/src/main/java/radiata/database/property/BatchDataSourceProperty.java
@@ -1,0 +1,13 @@
+package radiata.database.property;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("spring.datasource.hikari.batch")
+public record BatchDataSourceProperty(
+    String url,
+    String username,
+    String password,
+    String driverClassName
+) {
+
+}

--- a/database/src/main/java/radiata/database/property/MainDataSourceProperty.java
+++ b/database/src/main/java/radiata/database/property/MainDataSourceProperty.java
@@ -1,0 +1,13 @@
+package radiata.database.property;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("spring.datasource.hikari.main")
+public record MainDataSourceProperty(
+    String url,
+    String username,
+    String password,
+    String driverClassName
+) {
+
+}

--- a/database/src/main/java/radiata/database/property/RedisProperty.java
+++ b/database/src/main/java/radiata/database/property/RedisProperty.java
@@ -1,0 +1,11 @@
+package radiata.database.property;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("spring.data.redis")
+public record RedisProperty(
+    String host,
+    Integer port
+) {
+
+}

--- a/database/src/main/resources/application-database-dev.yml
+++ b/database/src/main/resources/application-database-dev.yml
@@ -1,9 +1,16 @@
 spring:
   datasource:
-    url: jdbc:postgresql://localhost:54321/radiata-dev-postgres-total
-    username: radiata
-    password: 1234
-    driver-class-name: org.postgresql.Driver
+    hikari:
+      main:
+        url: jdbc:postgresql://localhost:54321/radiata-dev-postgres-total
+        username: radiata
+        password: 1234
+        driver-class-name: org.postgresql.Driver
+      batch:
+        url: jdbc:postgresql://localhost:54322/radiata-dev-postgres-batch
+        username: radiata
+        password: 1234
+        driver-class-name: org.postgresql.Driver
 
   data:
     redis:

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -21,3 +21,14 @@ services:
       - TZ=Asia/Seoul
     volumes:
       - ./postgresql/init:/docker-entrypoint-initdb.d
+  batch:
+    container_name: radiata-dev-postgres-batch
+    image: postgres:latest
+    command: postgres -c 'max_connections=200' # 기본 설정은 100 이나, 동시 연결 수 제한을 200 까지 풀기 위함
+    ports:
+      - "54322:5432"
+    environment:
+      - POSTGRES_DB=radiata-dev-postgres-batch
+      - POSTGRES_USER=radiata
+      - POSTGRES_PASSWORD=1234
+      - TZ=Asia/Seoul

--- a/service/payment/payment-api/src/main/java/radiata/service/payment/api/PaymentApplication.java
+++ b/service/payment/payment-api/src/main/java/radiata/service/payment/api/PaymentApplication.java
@@ -2,8 +2,10 @@ package radiata.service.payment.api;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
-@SpringBootApplication(scanBasePackages = {"radiata.service.payment"})
+@SpringBootApplication(scanBasePackages = {"radiata.service.payment", "radiata.database"})
+@ConfigurationPropertiesScan(basePackages = {"radiata.service.payment", "radiata.database"})
 public class PaymentApplication {
 
     public static void main(String[] args) {


### PR DESCRIPTION
## #️⃣연관된 이슈

> - close #37 

## 📝작업 내용

> 기존의 단일 데이터소스를 다중 데이터소스로 변환했습니다. 
> 스프링 배치 5버전 부터는 메타데이터 테이블을 필수로 생성해야 하지만, 메인 DB와는 분리를 해두고자 진행했습니다. 
> 각 도메인에서는 스프링부트 애플리케이션의 어노테이션을 아래와 같이 변경해주시면 됩니다!!

```java
package radiata.service.payment.api;

import org.springframework.boot.SpringApplication;
import org.springframework.boot.autoconfigure.SpringBootApplication;
import org.springframework.boot.context.properties.ConfigurationPropertiesScan;

@SpringBootApplication(scanBasePackages = {"radiata.service.payment", "radiata.database"}) // 여기 1 !!
@ConfigurationPropertiesScan(basePackages = {"radiata.service.payment", "radiata.database"}) // 여기 2 !!
public class PaymentApplication {

    public static void main(String[] args) {
        SpringApplication.run(PaymentApplication.class, args);
    }
}
```
> 이렇게 작성해두면 `core 모듈`에서는 따로 컴포넌트 스캔할 필요가 없어지더라구요!!

> `DatabaseModuleConfig` 클래스는 database 모듈의 루트 패키지에 작성을 해두었습니다. 
> 이유는 `@ComponentScan`은 빈을 스캔하고, `@EnableAutoConfiguration`은 자동으로 개발자가 등록한 빈을 자동으로 설정해주는데, 따로 패키지를 지정할 수 없어서 최상단 패키지로 올려서 한번에 스캔하도록 하고, `database 모듈`을 의존하는 모듈은 `DatabaseModuleConfig` 클래스가 있는 패키지만 스캔하도록 작성을 해두었습니다. 

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?