### PR TITLE
[#35] [Feat] 주문 서비스 -OpenFeign & Kafka 추가

### DIFF
--- a/common/src/main/java/radiata/common/domain/order/dto/request/OrderCreateRequestDto.java
+++ b/common/src/main/java/radiata/common/domain/order/dto/request/OrderCreateRequestDto.java
@@ -5,6 +5,7 @@ import java.util.List;
 public record OrderCreateRequestDto(
     String address,
     String comment,
+    Integer point,
     List<OrderItemCreateRequestDto> itemList) {
 
 }

--- a/common/src/main/java/radiata/common/domain/order/dto/request/OrderItemCreateRequestDto.java
+++ b/common/src/main/java/radiata/common/domain/order/dto/request/OrderItemCreateRequestDto.java
@@ -2,7 +2,7 @@ package radiata.common.domain.order.dto.request;
 
 public record OrderItemCreateRequestDto(
     String productId,
-    String timesaleProductId,
+    String timeSaleProductId,
     String couponIssuedId,
     Integer quantity,
     Integer unitPrice) {

--- a/common/src/main/java/radiata/common/domain/order/dto/response/OrderItemResponseDto.java
+++ b/common/src/main/java/radiata/common/domain/order/dto/response/OrderItemResponseDto.java
@@ -4,13 +4,14 @@ import lombok.AccessLevel;
 import lombok.Builder;
 
 @Builder(access = AccessLevel.PRIVATE)
-public record OrderItemResponseDto(String orderItemId, String orderId, String productId, String couponIssuedId,
-                                   Integer quantity, Integer unitPrice, Integer paymentPrice) {
+public record OrderItemResponseDto(String orderItemId, String orderId, String productId, String timeSaleProductId,
+                                   String couponIssuedId, Integer quantity, Integer unitPrice, Integer paymentPrice) {
 
     public static OrderItemResponseDto of(
         String orderItemId,
         String orderId,
         String productId,
+        String timeSaleProductId,
         String couponIssuedId,
         Integer quantity,
         Integer unitPrice,
@@ -21,6 +22,7 @@ public record OrderItemResponseDto(String orderItemId, String orderId, String pr
             .orderItemId(orderItemId)
             .orderId(orderId)
             .productId(productId)
+            .timeSaleProductId(timeSaleProductId)
             .couponIssuedId(couponIssuedId)
             .quantity(quantity)
             .unitPrice(unitPrice)

--- a/common/src/main/java/radiata/common/message/ExceptionMessage.java
+++ b/common/src/main/java/radiata/common/message/ExceptionMessage.java
@@ -4,6 +4,7 @@ import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.CONFLICT;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.http.HttpStatus.PAYMENT_REQUIRED;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -35,15 +36,18 @@ public enum ExceptionMessage {
     USER_DUPLICATE_EMAIL(BAD_REQUEST, "3002", "이메일이 중복 됩니다."),
     USER_NOT_FOUND(NOT_FOUND.httpStatus, "3003", "사용자가 존재하지 않습니다."),
 
-  
+
     /* 주문 5000번대 */
-  
+
     // 현재 주문 상태에서 바뀔 수 없는 주문 상태로 변경하려 할 때
     INVALID_ORDER_STATUS(CONFLICT, "5001", "현재 주문 상태에서는 요청하신 상태 변경이 불가합니다."),
     // 결제 요청 금액과 최종 주문 금액 값이 일치하지 않을 때
     NOT_EQUALS_PRICE(CONFLICT, "5002", "결제 요청 금액과 주문 금액이 일치하지 않습니다."),
     // 주문 취소가 가능하지 않은 주문 상태일 때.
     IMPOSSIBLE_CANCEL_ORDER_PAYMENT(CONFLICT, "5003", "주문 취소가 불가한 주문 상태입니다."),
+    // 상품 재고가 부족할 때
+    ORDER_CREATION_FAILED(BAD_REQUEST, "5004", "주문 생성에 실패했습니다."),
+
 
     /* 쿠폰 6000번대 */
 

--- a/service/order/order-api/build.gradle
+++ b/service/order/order-api/build.gradle
@@ -9,6 +9,10 @@ repositories {
     mavenCentral()
 }
 
+ext {
+    set('springCloudVersion', "2023.0.3")
+}
+
 dependencies {
     /* 모듈 */
     implementation project(':common')
@@ -18,6 +22,12 @@ dependencies {
     /* 테스트 */
     testImplementation platform('org.junit:junit-bom:5.10.0')
     testImplementation 'org.junit.jupiter:junit-jupiter'
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+    }
 }
 
 test {

--- a/service/order/order-api/src/main/java/radiata/service/order/api/OrderApplication.java
+++ b/service/order/order-api/src/main/java/radiata/service/order/api/OrderApplication.java
@@ -4,9 +4,9 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication(scanBasePackages = {"radiata.service.order"})
-public class OrderApiApplication {
+public class OrderApplication {
 
     public static void main(String[] args) {
-        SpringApplication.run(OrderApiApplication.class, args);
+        SpringApplication.run(OrderApplication.class, args);
     }
 }

--- a/service/order/order-api/src/main/resources/application.yml
+++ b/service/order/order-api/src/main/resources/application.yml
@@ -6,3 +6,8 @@ spring:
 
 server:
   port: 8085
+
+eureka:
+  client:
+    service-url:
+      defaultZone: http://localhost:19090/eureka/

--- a/service/order/order-core/build.gradle
+++ b/service/order/order-core/build.gradle
@@ -17,6 +17,8 @@ dependencies {
     /* 모듈 */
     implementation project(':common')
     implementation project(':database')
+    implementation project(':service:payment:payment-core')
+    implementation project(':service:coupon:coupon-core')
 
     /* 라이브러리 */
     implementation 'com.github.ksuid:ksuid:1.1.2'

--- a/service/order/order-core/build.gradle
+++ b/service/order/order-core/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     implementation 'com.github.ksuid:ksuid:1.1.2'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+    implementation 'org.springframework.kafka:spring-kafka'
 
     /* 테스트 */
     testImplementation 'com.h2database:h2:2.1.214'

--- a/service/order/order-core/build.gradle
+++ b/service/order/order-core/build.gradle
@@ -9,6 +9,10 @@ repositories {
     mavenCentral()
 }
 
+ext {
+    set('springCloudVersion', "2023.0.3")
+}
+
 dependencies {
     /* 모듈 */
     implementation project(':common')
@@ -16,11 +20,19 @@ dependencies {
 
     /* 라이브러리 */
     implementation 'com.github.ksuid:ksuid:1.1.2'
+    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 
     /* 테스트 */
     testImplementation 'com.h2database:h2:2.1.214'
     testImplementation platform('org.junit:junit-bom:5.10.0')
     testImplementation 'org.junit.jupiter:junit-jupiter'
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+    }
 }
 
 test {

--- a/service/order/order-core/src/main/java/radiata/service/order/core/OrderCoreConfiguration.java
+++ b/service/order/order-core/src/main/java/radiata/service/order/core/OrderCoreConfiguration.java
@@ -1,11 +1,13 @@
 package radiata.service.order.core;
 
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
 // JpaRepository 빈 조회를 위한 ComponentScan 설정
 @EnableAutoConfiguration
+@EnableFeignClients
 @ComponentScan
 @Configuration
 public class OrderCoreConfiguration {

--- a/service/order/order-core/src/main/java/radiata/service/order/core/config/KafkaConfig.java
+++ b/service/order/order-core/src/main/java/radiata/service/order/core/config/KafkaConfig.java
@@ -1,0 +1,9 @@
+package radiata.service.order.core.config;
+
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+// TODO - 정해지면 종류 별(결제, 타임세일 상품, 발급 쿠폰, 상품, 적립금(유저))로 등록
+public class KafkaConfig {
+
+}

--- a/service/order/order-core/src/main/java/radiata/service/order/core/domain/model/entity/Order.java
+++ b/service/order/order-core/src/main/java/radiata/service/order/core/domain/model/entity/Order.java
@@ -78,13 +78,17 @@ public class Order extends BaseEntity {
     }
 
     public void setOrderPriceAndItems(Integer orderPrice, Set<OrderItem> orderItems) {
-        this.orderPrice = orderPrice;
+        this.orderPrice = orderPrice; // TODO- this.usedPoint 빼야할 걸?
         this.orderItems = orderItems;
     }
 
     public void setPaymentIdAndType(String paymentId, PaymentType paymentType) {
         this.paymentId = paymentId;
         this.paymentType = paymentType;
+    }
+
+    public void usePoint(Integer usedPoint) {
+        this.usedPoint = usedPoint;
     }
 
 

--- a/service/order/order-core/src/main/java/radiata/service/order/core/domain/model/entity/Order.java
+++ b/service/order/order-core/src/main/java/radiata/service/order/core/domain/model/entity/Order.java
@@ -18,6 +18,7 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLRestriction;
 import radiata.database.model.BaseEntity;
 import radiata.service.order.core.domain.model.constant.OrderStatus;
+import radiata.service.payment.core.domain.model.vo.PaymentType;
 
 @Entity
 @Table(name = "r_order")
@@ -49,7 +50,7 @@ public class Order extends BaseEntity {
 
     private String paymentId;
 
-    //    private PaymentType paymentType;
+    private PaymentType paymentType;
     // TODO - 사용 예정
     private Integer usedPoint;
 
@@ -81,10 +82,10 @@ public class Order extends BaseEntity {
         this.orderItems = orderItems;
     }
 
-//    public void setPaymentIdAndType(String paymentId, PaymentType paymentType) {
-//        this.paymentId = paymentId;
-//        this.paymentType = paymentType;
-//    }
+    public void setPaymentIdAndType(String paymentId, PaymentType paymentType) {
+        this.paymentId = paymentId;
+        this.paymentType = paymentType;
+    }
 
 
     // 주문 상태 변경

--- a/service/order/order-core/src/main/java/radiata/service/order/core/domain/model/entity/Order.java
+++ b/service/order/order-core/src/main/java/radiata/service/order/core/domain/model/entity/Order.java
@@ -76,17 +76,16 @@ public class Order extends BaseEntity {
             .build();
     }
 
-    public void setOrderPrice(Integer orderPrice) {
+    public void setOrderPriceAndItems(Integer orderPrice, Set<OrderItem> orderItems) {
         this.orderPrice = orderPrice;
-    }
-
-    public void setPaymentId(String paymentId) {
-        this.paymentId = paymentId;
-    }
-
-    public void setOrderItems(Set<OrderItem> orderItems) {
         this.orderItems = orderItems;
     }
+
+//    public void setPaymentIdAndType(String paymentId, PaymentType paymentType) {
+//        this.paymentId = paymentId;
+//        this.paymentType = paymentType;
+//    }
+
 
     // 주문 상태 변경
     public void updateOrderStatus(

--- a/service/order/order-core/src/main/java/radiata/service/order/core/domain/model/entity/OrderItem.java
+++ b/service/order/order-core/src/main/java/radiata/service/order/core/domain/model/entity/OrderItem.java
@@ -34,6 +34,8 @@ public class OrderItem extends BaseEntity {
     @Column(nullable = false)
     private String productId;
 
+    private String timeSaleProductId;
+
     private String couponIssuedId;
 
     @Column(nullable = false)
@@ -53,6 +55,7 @@ public class OrderItem extends BaseEntity {
         String id,
         Order order,
         String productId,
+        String timeSaleProductId,
         String couponIssuedId,
         Integer quantity,
         Integer unitPrice) {
@@ -62,6 +65,7 @@ public class OrderItem extends BaseEntity {
             .id(id)
             .order(order)
             .productId(productId)
+            .timeSaleProductId(timeSaleProductId)
             .couponIssuedId(couponIssuedId)
             .quantity(quantity)
             .unitPrice(unitPrice)

--- a/service/order/order-core/src/main/java/radiata/service/order/core/service/OrderItemService.java
+++ b/service/order/order-core/src/main/java/radiata/service/order/core/service/OrderItemService.java
@@ -1,13 +1,26 @@
 package radiata.service.order.core.service;
 
+import feign.FeignException;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import radiata.common.annotation.Implementation;
+import radiata.common.domain.order.dto.request.OrderCreateRequestDto;
+import radiata.common.domain.order.dto.request.OrderItemCreateRequestDto;
 import radiata.common.domain.order.dto.response.OrderItemResponseDto;
+import radiata.common.exception.BusinessException;
+import radiata.common.message.ExceptionMessage;
+import radiata.service.order.core.domain.model.entity.Order;
 import radiata.service.order.core.domain.model.entity.OrderItem;
+import radiata.service.order.core.implemetation.OrderIdCreator;
+import radiata.service.order.core.service.client.CouponIssueClient;
+import radiata.service.order.core.service.client.ProductClient;
+import radiata.service.order.core.service.client.TimeSaleProductClient;
+import radiata.service.order.core.service.client.UserClient;
 import radiata.service.order.core.service.mapper.OrderItemMapper;
 
 @Implementation
@@ -16,6 +29,11 @@ import radiata.service.order.core.service.mapper.OrderItemMapper;
 public class OrderItemService {
 
     private final OrderItemMapper orderItemMapper;
+    private final OrderIdCreator orderIdCreator;
+    private final TimeSaleProductClient timeSaleProductClient;
+    private final ProductClient productClient;
+    private final CouponIssueClient couponIssueClient;
+    private final UserClient userClient;
 
     public Set<OrderItemResponseDto> toDtoSet(Set<OrderItem> orderItems) {
 
@@ -25,22 +43,133 @@ public class OrderItemService {
     }
 
 
-    // SAGA 보상 트랜잭션
-    public void rollbackTransaction(List<String> deductedProducts, List<String> usedCoupons) {
-
+    // 보상 트랜잭션 - 타임 세일 상품 재고
+    private void rollbackTimeSaleStock(List<String> deductedTimeSaleStocks) {
         try {
-            // 상품 재고 - 보상
-            deductedProducts.forEach(productInfo -> {
+            // 타임세일 상품 재고 증감 요청
+            deductedTimeSaleStocks.forEach(timeSaleProduct -> {
+                // TODO - kafka 를 이용한 비동기 처리
+                // A->B->C
+            });
+        } catch (Exception e) {
+            log.info(" [Rollback Error]: TimeSale-Service ");
+        }
+    }
+
+    // 보상 트랜잭션 - 상품 재고
+    private void rollbackProductStock(List<String> deductedProductStocks) {
+        try {
+            // 상품 재고 증감 요청
+            deductedProductStocks.forEach(product -> {
                 // TODO - kafka 를 이용한 비동기 처리
             });
-            // 쿠폰 상태 값 - 보상
-            usedCoupons.forEach(couponId -> {
+        } catch (Exception e) {
+            log.info(" [Rollback Error]: Product-Service ");
+        }
+    }
+
+    // 보상 트랜잭션 - 쿠폰 상태
+    private void rollbackCoupons(List<String> usedCoupons) {
+        try {
+            // 쿠폰 상태 변경 요청(USED -> ISSUED)
+            usedCoupons.forEach(usedCouponId -> {
                 // TODO - kafka 를 이용한 비동기 처리
             });
+        } catch (Exception e) {
+            log.info(" [Rollback Error]: Coupon-Service ");
+        }
+    }
+
+    // 보상 트랜잭션 - 적립금
+    private void rollbackRewardPoint(String userId) {
+        try {
+            // 적립금 증감 요청
+            // TODO - kafka 를 이용한 비동기 처리
 
         } catch (Exception e) {
-            log.info("##########[보상 트랜잭션 처리 중, 예외 발생]##########");
-            throw new RuntimeException(e);
+            log.info(" [Rollback Error]: User(Point)-Service ");
         }
+    }
+
+    // 주문 등록 - 보상 트랜잭션
+    private void createOrderRollbackTransaction(List<String> deductedTimeSales, List<String> deductedProducts,
+        List<String> usedCoupons) {
+
+        rollbackTimeSaleStock(deductedTimeSales);
+        rollbackProductStock(deductedProducts);
+        rollbackCoupons(usedCoupons);
+    }
+
+    // 주문 상품 처리 로직
+    public void processOrderItems(OrderCreateRequestDto requestDto, Order order, String userId) {
+        // 보상 트랜잭션 관리 변수
+        // TODO - 타입 클래스를 따로 만들어 줘야할 거 같음 - 사이즈, 갯수, 아이디
+        List<String> deductedTimeSales = new ArrayList<>(); // 타임세일 재고 차감 목록
+        List<String> deductedProducts = new ArrayList<>();  // 재고 차감 목록
+        List<String> usedCoupons = new ArrayList<>();       // 사용된 쿠폰 목록
+        // 주문 상품 목록 - set
+        Set<OrderItem> orderItems = new HashSet<>();
+        // 총 주문 금액 - set
+        int orderPrice = 0;
+
+        for (OrderItemCreateRequestDto itemCreateDto : requestDto.itemList()) {
+            try {
+//                // ID, 갯수, 사이즈 담겨있는 Dto 생성 후 사용
+//                int quantity = itemCreateDto.quantity();
+//                Object size = itemCreateDto;
+//
+//                // 1️⃣ 타임세일 제품 확인
+//                String timeSaleProductId = itemCreateDto.timeSaleProductId();
+//                if (timeSaleProductId != null) {
+//                    // 타임세일 상품에 재고 존재? -> 요청 + 롤백처리 필요.
+//                    timeSaleProductClient.checkAndDeductTimeSaleProduct(timeSaleProductId);
+//                    deductedTimeSales.add(timeSaleProductId);
+//                }
+//                // 2️⃣ 재고 확인 및 차감
+//                String productId = itemCreateDto.productId();
+//
+//                productClient.checkAndDeductStock(productId);   // 재고 확인 및 차감
+//                deductedProducts.add(productId);                // 재고 차감 목록 추가
+//
+//                // 3️⃣ 쿠폰 사용 여부 체크
+//                String couponIssuedId = itemCreateDto.couponIssuedId();
+//                if (couponIssuedId != null) {
+//                    // 아래 둘 중 하나에서 쿠폰 할인율 or 할인 금액을 가져와야함.
+//                    couponIssueClient.getCouponIssue(couponIssuedId, userId).getBody();  // 쿠폰 조회
+//                    couponIssueClient.useCouponIssue(couponIssuedId, userId).getBody();  // 쿠폰 사용
+//                    usedCoupons.add(couponIssuedId);                                     // 사용된 쿠폰 목록 추가
+//                }
+
+                // 주문 상품 ID 생성 및 주문 상품 목록에 추가
+                String orderItemId = orderIdCreator.create();
+                OrderItem orderItem = orderItemMapper.toEntity(itemCreateDto, orderItemId, order);
+                orderItems.add(orderItem);
+                // 주문 금액 추가 - 할인율 or 할인금액 적용
+                orderPrice += (orderItem.getUnitPrice() * orderItem.getQuantity());
+
+            } catch (FeignException e) {
+                // 보상 트랜잭션 - 비동기 처리 (Kafka 사용)
+                createOrderRollbackTransaction(deductedTimeSales, deductedProducts, usedCoupons);
+                throw new BusinessException(ExceptionMessage.ORDER_CREATION_FAILED);
+            }
+        }
+
+        // 적립금 사용 시
+        try {
+            int point = requestDto.point();
+//            if (point > 0) {
+//                // 적립금 조회 및 차감 요청
+//                userClient.checkAndUseRewardPoint(userId);
+//                order.usePoint(point);
+//            }
+
+        } catch (FeignException e) {
+            // 보상 트랜잭션 - 비동기 처리 (Kafka 사용)
+            createOrderRollbackTransaction(deductedTimeSales, deductedProducts, usedCoupons);
+            throw new BusinessException(ExceptionMessage.ORDER_CREATION_FAILED);
+        }
+
+        // 주문 - 금액 & 상품 목록 지정
+        order.setOrderPriceAndItems(orderPrice, orderItems);
     }
 }

--- a/service/order/order-core/src/main/java/radiata/service/order/core/service/OrderItemService.java
+++ b/service/order/order-core/src/main/java/radiata/service/order/core/service/OrderItemService.java
@@ -1,14 +1,17 @@
 package radiata.service.order.core.service;
 
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import radiata.common.annotation.Implementation;
 import radiata.common.domain.order.dto.response.OrderItemResponseDto;
 import radiata.service.order.core.domain.model.entity.OrderItem;
 import radiata.service.order.core.service.mapper.OrderItemMapper;
 
 @Implementation
+@Slf4j(topic = "OrderItemService")
 @RequiredArgsConstructor
 public class OrderItemService {
 
@@ -19,5 +22,25 @@ public class OrderItemService {
         return orderItems.stream()
             .map(orderItemMapper::toDto)
             .collect(Collectors.toSet());
+    }
+
+
+    // SAGA 보상 트랜잭션
+    public void rollbackTransaction(List<String> deductedProducts, List<String> usedCoupons) {
+
+        try {
+            // 상품 재고 - 보상
+            deductedProducts.forEach(productInfo -> {
+                // TODO - kafka 를 이용한 비동기 처리
+            });
+            // 쿠폰 상태 값 - 보상
+            usedCoupons.forEach(couponId -> {
+                // TODO - kafka 를 이용한 비동기 처리
+            });
+
+        } catch (Exception e) {
+            log.info("##########[보상 트랜잭션 처리 중, 예외 발생]##########");
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/service/order/order-core/src/main/java/radiata/service/order/core/service/OrderService.java
+++ b/service/order/order-core/src/main/java/radiata/service/order/core/service/OrderService.java
@@ -1,6 +1,9 @@
 package radiata.service.order.core.service;
 
+import feign.FeignException;
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -9,6 +12,8 @@ import radiata.common.domain.order.dto.request.OrderCreateRequestDto;
 import radiata.common.domain.order.dto.request.OrderItemCreateRequestDto;
 import radiata.common.domain.order.dto.request.OrderPaymentRequestDto;
 import radiata.common.domain.order.dto.response.OrderResponseDto;
+import radiata.common.exception.BusinessException;
+import radiata.common.message.ExceptionMessage;
 import radiata.service.order.core.domain.model.constant.OrderStatus;
 import radiata.service.order.core.domain.model.entity.Order;
 import radiata.service.order.core.domain.model.entity.OrderItem;
@@ -16,6 +21,9 @@ import radiata.service.order.core.implemetation.OrderIdCreator;
 import radiata.service.order.core.implemetation.OrderReader;
 import radiata.service.order.core.implemetation.OrderSaver;
 import radiata.service.order.core.implemetation.OrderValidator;
+import radiata.service.order.core.service.client.CouponIssueClient;
+import radiata.service.order.core.service.client.ProductClient;
+import radiata.service.order.core.service.client.UserClient;
 import radiata.service.order.core.service.mapper.OrderItemMapper;
 import radiata.service.order.core.service.mapper.OrderMapper;
 
@@ -30,6 +38,9 @@ public class OrderService {
     private final OrderItemMapper orderItemMapper;
     private final OrderValidator orderValidator;
     private final OrderItemService orderItemService;
+    private final ProductClient productClient;
+    private final CouponIssueClient couponIssueClient;
+    private final UserClient userClient;
 
 
     // 주문 생성
@@ -43,34 +54,39 @@ public class OrderService {
         Set<OrderItem> orderItems = new HashSet<>();
         // 총 주문 금액 - set
         int orderPrice = 0;
-        // 상품 별 체크
+        // 보상 트랜잭션 관리 변수
+        // TODO - 타입 클래스를 따로 만들어 줘야할 거 같음 - 사이즈, 갯수, 아이디
+        List<String> deductedProducts = new ArrayList<>();  // 재고 차감 목록
+        List<String> usedCoupons = new ArrayList<>();       // 사용된 쿠폰 목록
+
         for (OrderItemCreateRequestDto itemCreateDto : requestDto.itemList()) {
-            // TODO - FeignClient 사용(Product, CouponIssue, Point)
-                /* 1️⃣ 재고 확인 및 차감
-                    1) 성공 - 다음
+            try {
+//                // 1️⃣ 재고 확인 및 차감
+//                String productId = itemCreateDto.productId();
+//                productClient.getProductInfo(productId);  // 상품 조회
+////                productClient.deductStock(productId);     // 재고 차감
+//                deductedProducts.add(productId);          // 재고 차감 목록 추가
+//
+//                // 2️⃣ 쿠폰 사용 여부 체크
+//                String couponIssuedId = itemCreateDto.couponIssuedId();
+//                if (couponIssuedId != null) {
+//                    couponIssueClient.getCouponIssue(couponIssuedId, userId).getBody();  // 쿠폰 조회
+//                    couponIssueClient.useCouponIssue(couponIssuedId, userId).getBody();  // 쿠폰 사용
+//                    usedCoupons.add(couponIssuedId);                                     // 사용된 쿠폰 목록 추가
+//                }
 
-                    2) 실패 - 재고 차감 -> 증감 요청
-                */
+                // 주문 상품 ID 생성 및 주문 상품 목록에 추가
+                String orderItemId = orderIdCreator.create();
+                OrderItem orderItem = orderItemMapper.toEntity(itemCreateDto, orderItemId, order);
+                orderItems.add(orderItem);
+                // 주문 금액 추가
+                orderPrice += (orderItem.getUnitPrice() * orderItem.getQuantity());
 
-                /* 2️⃣ 쿠폰 사용 여부 체크
-                    1) 미사용 - Null
-                    👉 다음 단계
-
-                    2) 사용 - NotNull
-                    👉 쿠폰 상태 값 변경 시도
-                        1) 성공 - 쿠폰 사용(상태 값 ISSUED -> USED 변경) -> 다음
-                        2) 실패 - 재고 차감 -> 증감 요청(보상1)
-                 */
-
-            // 주문 상품 ID 생성
-            String orderItemId = orderIdCreator.create();
-            // 주문 상품 객체 생성
-            OrderItem orderItem = orderItemMapper.toEntity(itemCreateDto, orderItemId, order);
-            // 주문 상품 목록에 추가
-            orderItems.add(orderItem);
-            // TODO - 쿠폰 할인율 적용시켜야 됨
-            // 주문 금액 추가
-            orderPrice += (orderItem.getUnitPrice() * orderItem.getQuantity());
+            } catch (FeignException e) {
+                // 실패 시 SAGA 보상 트랜잭션 처리 (Kafka 사용)
+                orderItemService.rollbackTransaction(deductedProducts, usedCoupons);
+                throw new BusinessException(ExceptionMessage.ORDER_CREATION_FAILED);
+            }
         }
 
         /* 적립금 사용 여부 체크

--- a/service/order/order-core/src/main/java/radiata/service/order/core/service/client/CouponIssueClient.java
+++ b/service/order/order-core/src/main/java/radiata/service/order/core/service/client/CouponIssueClient.java
@@ -1,0 +1,21 @@
+package radiata.service.order.core.service.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+import radiata.common.response.CommonResponse;
+
+@FeignClient(name = "coupon-service")
+public interface CouponIssueClient {
+
+    @GetMapping("/couponissues/{couponIssueId}")
+    ResponseEntity<? extends CommonResponse> getCouponIssue(@PathVariable String couponIssueId,
+        @RequestHeader("X-UserId") String userId);
+
+    @PatchMapping("/couponissues/{couponIssueId}")
+    ResponseEntity<? extends CommonResponse> useCouponIssue(@PathVariable String couponIssueId,
+        @RequestHeader("X-UserId") String userId);
+}

--- a/service/order/order-core/src/main/java/radiata/service/order/core/service/client/PaymentClient.java
+++ b/service/order/order-core/src/main/java/radiata/service/order/core/service/client/PaymentClient.java
@@ -1,0 +1,15 @@
+package radiata.service.order.core.service.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import radiata.common.domain.payment.dto.request.TossPaymentCreateRequestDto;
+import radiata.common.domain.payment.dto.response.TossPaymentCreateResponseDto;
+import radiata.common.response.SuccessResponse;
+
+@FeignClient(name = "payment-service")
+public interface PaymentClient {
+
+    @PostMapping("/payments/toss")
+    SuccessResponse<TossPaymentCreateResponseDto> requestTossPayment(@RequestBody TossPaymentCreateRequestDto request);
+}

--- a/service/order/order-core/src/main/java/radiata/service/order/core/service/client/ProductClient.java
+++ b/service/order/order-core/src/main/java/radiata/service/order/core/service/client/ProductClient.java
@@ -9,7 +9,7 @@ import radiata.common.response.SuccessResponse;
 public interface ProductClient {
 
     @GetMapping("/products/{productId}")
-        // TODO - 타입 변경 예정(String -> ProductResponseDto?)
-    SuccessResponse<String> getProductInfo(@PathVariable("productId") String productId);
+        // TODO - 타입 변경 예정(String -> ProductResponseDto?) + 매개변수 변경 (사이즈, 갯수 같이 요청)
+    SuccessResponse<String> checkAndDeductStock(@PathVariable("productId") String productId);
 
 }

--- a/service/order/order-core/src/main/java/radiata/service/order/core/service/client/ProductClient.java
+++ b/service/order/order-core/src/main/java/radiata/service/order/core/service/client/ProductClient.java
@@ -1,0 +1,15 @@
+package radiata.service.order.core.service.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import radiata.common.response.SuccessResponse;
+
+@FeignClient(name = "product-service")
+public interface ProductClient {
+
+    @GetMapping("/products/{productId}")
+        // TODO - 타입 변경 예정(String -> ProductResponseDto?)
+    SuccessResponse<String> getProductInfo(@PathVariable("productId") String productId);
+
+}

--- a/service/order/order-core/src/main/java/radiata/service/order/core/service/client/TimeSaleProductClient.java
+++ b/service/order/order-core/src/main/java/radiata/service/order/core/service/client/TimeSaleProductClient.java
@@ -11,5 +11,5 @@ public interface TimeSaleProductClient {
 
     // TODO - 수정 가능성 O (미확정)
     @GetMapping("/timesale-products/{timeSaleProductId}")
-    ResponseEntity<? extends CommonResponse> getTimeSaleProduct(@PathVariable String timeSaleProductId);
+    ResponseEntity<? extends CommonResponse> checkAndDeductTimeSaleProduct(@PathVariable String timeSaleProductId);
 }

--- a/service/order/order-core/src/main/java/radiata/service/order/core/service/client/TimeSaleProductClient.java
+++ b/service/order/order-core/src/main/java/radiata/service/order/core/service/client/TimeSaleProductClient.java
@@ -1,0 +1,15 @@
+package radiata.service.order.core.service.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import radiata.common.response.CommonResponse;
+
+@FeignClient(name = "timesale-service")
+public interface TimeSaleProductClient {
+
+    // TODO - 수정 가능성 O (미확정)
+    @GetMapping("/timesale-products/{timeSaleProductId}")
+    ResponseEntity<? extends CommonResponse> getTimeSaleProduct(@PathVariable String timeSaleProductId);
+}

--- a/service/order/order-core/src/main/java/radiata/service/order/core/service/client/UserClient.java
+++ b/service/order/order-core/src/main/java/radiata/service/order/core/service/client/UserClient.java
@@ -9,5 +9,5 @@ public interface UserClient {
 
     // TODO - uri 뒤에 /{userId} 붙이는게 RestFul 원칙?
     @GetMapping("/users")
-    CommonResponse getUserInfo(String userId);
+    CommonResponse checkAndUseRewardPoint(String userId);
 }

--- a/service/order/order-core/src/main/java/radiata/service/order/core/service/client/UserClient.java
+++ b/service/order/order-core/src/main/java/radiata/service/order/core/service/client/UserClient.java
@@ -1,0 +1,13 @@
+package radiata.service.order.core.service.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import radiata.common.response.CommonResponse;
+
+@FeignClient(name = "user-service")
+public interface UserClient {
+
+    // TODO - uri 뒤에 /{userId} 붙이는게 RestFul 원칙?
+    @GetMapping("/users")
+    CommonResponse getUserInfo(String userId);
+}

--- a/service/order/order-core/src/main/java/radiata/service/order/core/service/mapper/OrderItemMapper.java
+++ b/service/order/order-core/src/main/java/radiata/service/order/core/service/mapper/OrderItemMapper.java
@@ -15,6 +15,7 @@ public class OrderItemMapper {
             orderItemId,
             order,
             requestDto.productId(),
+            requestDto.timeSaleProductId(),
             requestDto.couponIssuedId(),
             requestDto.quantity(),
             requestDto.unitPrice()
@@ -27,6 +28,7 @@ public class OrderItemMapper {
             orderItem.getId(),
             orderItem.getOrder().getId(),
             orderItem.getProductId(),
+            orderItem.getTimeSaleProductId(),
             orderItem.getCouponIssuedId(),
             orderItem.getQuantity(),
             orderItem.getUnitPrice(),

--- a/service/order/order-core/src/test/java/radiata/service/order/core/domain/model/entity/OrderTest.java
+++ b/service/order/order-core/src/test/java/radiata/service/order/core/domain/model/entity/OrderTest.java
@@ -30,6 +30,7 @@ class OrderTest {
             KsuidGenerator.generate(),
             order,
             "productId-01",
+            "timeSaleId-01",
             "couponIssuedId-01",
             5,
             10000
@@ -58,6 +59,7 @@ class OrderTest {
         assertThat(orderItem.getId()).isNotBlank();
         assertThat(orderItem.getOrder().getId()).isEqualTo(order.getId());
         assertThat(orderItem.getProductId()).isEqualTo("productId-01");
+        assertThat(orderItem.getTimeSaleProductId()).isEqualTo("timeSaleId-01");
         assertThat(orderItem.getCouponIssuedId()).isEqualTo("couponIssuedId-01");
         assertThat(orderItem.getQuantity()).isEqualTo(5);
         assertThat(orderItem.getUnitPrice()).isEqualTo(10000);

--- a/service/order/order-core/src/test/java/radiata/service/order/core/domain/model/entity/OrderTest.java
+++ b/service/order/order-core/src/test/java/radiata/service/order/core/domain/model/entity/OrderTest.java
@@ -65,14 +65,14 @@ class OrderTest {
     }
 
     @Test
-    @DisplayName("주문 상품목록 지정 Test")
+    @DisplayName("주문 - 총 금액 & 상품 목록 지정 Test")
     void testSetOrderItems() {
         // given
         Set<OrderItem> orderItems = new HashSet<>();
         orderItems.add(orderItem);
 
         // when
-        order.setOrderItems(orderItems);
+        order.setOrderPriceAndItems(0, orderItems);
 
         // then
         for (OrderItem orderItem2 : order.getOrderItems()) {

--- a/service/order/order-core/src/test/java/radiata/service/order/core/domain/service/OrderServiceTest.java
+++ b/service/order/order-core/src/test/java/radiata/service/order/core/domain/service/OrderServiceTest.java
@@ -52,7 +52,7 @@ class OrderServiceTest {
             itemList.add(itemListRequestDto);
         }
 
-        orderCreateRequestDto = new OrderCreateRequestDto("address-01", "comment-01", itemList);
+        orderCreateRequestDto = new OrderCreateRequestDto("address-01", "comment-01", 20000, itemList);
 
         // 주문 생성
         createdOrder = orderService.createOrder(orderCreateRequestDto, "user-01");


### PR DESCRIPTION
## #️⃣연관된 이슈

> - closed: #35 

## 📝작업 내용

> 각 도메인과 연동할 방법으로 FeignClient와 Kafka 기본 설정을 추가했습니다.
주문 등록 로직에서 예상 시나리오대로 코드 작성을 진행했고 일단 주석처리 했습니다.
추후에 수정 될 가능성이 매우매우!!!   많습니다!
각 서비스에서 kafka Consumer 혹은 FeignClient로 사용할 메서드가 구현되시면 바로 수정해서 적용하겠습니다!

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 주문 등록에서 processOrderItems 메서드를 어떻게 더 쪼개야 예쁘게 쪼갤 수 있을까요??,, 