### PR TITLE
[#42] fix(deploy): working directory와 gradlew 경로를 분리

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -34,8 +34,7 @@ jobs:
       - run: ls -al
 
       - name: Build with Gradle Wrapper
-        run: ./gradlew clean build -x test
-        working-directory: ${{ matrix.service }}
+        run: ./gradlew clean build -x test --project-dir ${{ matrix.service }}
 
   docker:
     name: Build Docker image and push to Docker Hub


### PR DESCRIPTION
## #️⃣연관된 이슈

> - close #42 

## 📝작업 내용

> 배포를 위해 CD 작업을 했습니다. 
> CD 테스트를 위해 일시적으로 approve 없이 merge 할 수 있도록 해두었습니다. 

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?