### PR TITLE
[#82] feat(payment): 간편결제 유저 도메인 API 추가 

### DIFF
--- a/common/src/main/java/radiata/common/domain/payment/dto/request/PayUserAddMoneyRequestDto.java
+++ b/common/src/main/java/radiata/common/domain/payment/dto/request/PayUserAddMoneyRequestDto.java
@@ -1,0 +1,19 @@
+package radiata.common.domain.payment.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Positive;
+
+public record PayUserAddMoneyRequestDto(
+
+    @Positive(message = "금액은 0보다 커야 합니다.")
+    @NotNull(message = "금액은 필수입니다.")
+    Long amount,
+
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    @Pattern(regexp = "^[0-9]{6}$", message = "비밀번호는 숫자 6자리로 입력해주세요.")
+    String password
+) {
+
+}

--- a/common/src/main/java/radiata/common/domain/payment/dto/request/PayUserCreateRequestDto.java
+++ b/common/src/main/java/radiata/common/domain/payment/dto/request/PayUserCreateRequestDto.java
@@ -1,0 +1,13 @@
+package radiata.common.domain.payment.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record PayUserCreateRequestDto(
+
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    @Pattern(regexp = "^[0-9]{6}$", message = "비밀번호는 숫자 6자리로 입력해주세요.")
+    String password
+) {
+
+}

--- a/common/src/main/java/radiata/common/domain/payment/dto/request/PayUserSubtractMoneyRequestDto.java
+++ b/common/src/main/java/radiata/common/domain/payment/dto/request/PayUserSubtractMoneyRequestDto.java
@@ -1,0 +1,19 @@
+package radiata.common.domain.payment.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Positive;
+
+public record PayUserSubtractMoneyRequestDto(
+
+    @Positive(message = "금액은 0보다 커야 합니다.")
+    @NotNull(message = "금액은 필수입니다.")
+    Long amount,
+
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    @Pattern(regexp = "^[0-9]{6}$", message = "비밀번호는 숫자 6자리로 입력해주세요.")
+    String password
+) {
+
+}

--- a/common/src/main/java/radiata/common/domain/payment/dto/response/PayUserResponseDto.java
+++ b/common/src/main/java/radiata/common/domain/payment/dto/response/PayUserResponseDto.java
@@ -1,0 +1,9 @@
+package radiata.common.domain.payment.dto.response;
+
+public record PayUserResponseDto(
+    String userId,
+    String payUserId,
+    Long money
+) {
+
+}

--- a/common/src/main/java/radiata/common/message/ExceptionMessage.java
+++ b/common/src/main/java/radiata/common/message/ExceptionMessage.java
@@ -29,6 +29,9 @@ public enum ExceptionMessage {
 
     // 잔액 부족 402
     INSUFFICIENT_BALANCE(PAYMENT_REQUIRED, "2001", "충전금이 부족합니다."),
+    PAY_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "2002", "간편결제 사용자가 존재하지 않습니다."),
+    INVALID_PASSWORD(BAD_REQUEST, "2003", "비밀번호가 일치하지 않습니다."),
+    PAY_USER_DUPLICATE(BAD_REQUEST, "2004", "이미 등록된 사용자입니다."),
 
     /* 유저 3000번대 */
 

--- a/service/payment/payment-api/http/payuser-api.http
+++ b/service/payment/payment-api/http/payuser-api.http
@@ -1,0 +1,33 @@
+### 간편결제 유저 생성
+POST http://localhost:8080/payusers
+Content-Type: application/json
+X-Userid: 2nVDCU4ILPYK6ezjTUNqAHXK3jQ
+
+{
+  "password": "123456"
+}
+
+### 간편결제 유저 조회
+GET http://localhost:8080/payusers
+Content-Type: application/json
+X-Userid: 2nVDCU4ILPYK6ezjTUNqAHXK3jQ
+
+### 간편결제 유저 충전금 충전
+PATCH http://localhost:8080/payusers/money/add
+Content-Type: application/json
+X-Userid: 2nVDCU4ILPYK6ezjTUNqAHXK3jQ
+
+{
+  "password": "123456",
+  "amount": 1000
+}
+
+### 간편결제 유저 충전금 출금
+PATCH http://localhost:8080/payusers/money/subtract
+Content-Type: application/json
+X-Userid: 2nVDCU4ILPYK6ezjTUNqAHXK3jQ
+
+{
+  "password": "123456",
+  "amount": 1000
+}

--- a/service/payment/payment-api/src/main/java/radiata/service/payment/api/presentation/PayUserController.java
+++ b/service/payment/payment-api/src/main/java/radiata/service/payment/api/presentation/PayUserController.java
@@ -1,0 +1,63 @@
+package radiata.service.payment.api.presentation;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import radiata.common.domain.payment.dto.request.PayUserAddMoneyRequestDto;
+import radiata.common.domain.payment.dto.request.PayUserCreateRequestDto;
+import radiata.common.domain.payment.dto.request.PayUserSubtractMoneyRequestDto;
+import radiata.common.domain.payment.dto.response.PayUserResponseDto;
+import radiata.common.message.SuccessMessage;
+import radiata.common.response.SuccessResponse;
+import radiata.service.payment.core.service.PayUserService;
+
+@Tag(name = "간편결제 사용자", description = "간편결제 사용자 API")
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/payusers")
+public class PayUserController {
+
+    private final PayUserService payUserService;
+
+    @GetMapping()
+    public SuccessResponse<PayUserResponseDto> getPayUser(@RequestHeader("X-UserId") String userId) {
+        PayUserResponseDto response = payUserService.getPayUser(userId);
+        return SuccessResponse.success(SuccessMessage.OK.getMessage(), response);
+    }
+
+    @PostMapping()
+    public SuccessResponse<PayUserResponseDto> signupPayUser(
+        @RequestHeader("X-UserId") String userId,
+        @Validated @RequestBody PayUserCreateRequestDto request
+    ) {
+        PayUserResponseDto response = payUserService.signupPayUser(userId, request);
+        return SuccessResponse.success(SuccessMessage.OK.getMessage(), response);
+    }
+
+    @PatchMapping("/money/add")
+    public SuccessResponse<PayUserResponseDto> addMoney(
+        @RequestHeader("X-UserId") String userId,
+        @Validated @RequestBody PayUserAddMoneyRequestDto request
+    ) {
+        PayUserResponseDto response = payUserService.addMoney(userId, request);
+        return SuccessResponse.success(SuccessMessage.OK.getMessage(), response);
+    }
+
+    @PatchMapping("/money/subtract")
+    public SuccessResponse<PayUserResponseDto> subtractMoney(
+        @RequestHeader("X-UserId") String userId,
+        @Validated @RequestBody PayUserSubtractMoneyRequestDto request
+    ) {
+        PayUserResponseDto response = payUserService.subtractMoney(userId, request);
+        return SuccessResponse.success(SuccessMessage.OK.getMessage(), response);
+    }
+}

--- a/service/payment/payment-api/src/main/java/radiata/service/payment/api/presentation/PaymentController.java
+++ b/service/payment/payment-api/src/main/java/radiata/service/payment/api/presentation/PaymentController.java
@@ -1,5 +1,6 @@
 package radiata.service.payment.api.presentation;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -12,6 +13,7 @@ import radiata.common.message.SuccessMessage;
 import radiata.common.response.SuccessResponse;
 import radiata.service.payment.core.service.TossPaymentService;
 
+@Tag(name = "결제", description = "결제 API")
 @Slf4j
 @RestController
 @RequiredArgsConstructor

--- a/service/payment/payment-core/build.gradle
+++ b/service/payment/payment-core/build.gradle
@@ -23,6 +23,10 @@ dependencies {
 
     // spring security crypto
     implementation 'org.springframework.security:spring-security-crypto'
+    
+    // mapStruct
+    implementation 'org.mapstruct:mapstruct:1.5.5.Final'
+    annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
 
     /* test */
 

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/config/PasswordEncoderConfig.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/config/PasswordEncoderConfig.java
@@ -1,0 +1,15 @@
+package radiata.service.payment.core.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordEncoderConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/model/entity/FirmBankingRequestHistory.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/model/entity/FirmBankingRequestHistory.java
@@ -15,6 +15,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLRestriction;
+import radiata.database.model.BaseEntity;
 import radiata.service.payment.core.domain.model.vo.Account;
 import radiata.service.payment.core.domain.model.vo.FirmBankingRequestStatus;
 import radiata.service.payment.core.domain.model.vo.Money;
@@ -26,7 +27,7 @@ import radiata.service.payment.core.domain.model.vo.Money;
 @Builder // 빌더 패턴은 테스트 용도로만 사용
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED) // JPA 객체는 기본 생성자를 필요로 함
-public class FirmBankingRequestHistory {
+public class FirmBankingRequestHistory extends BaseEntity {
 
     @Id
     private String id;

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/model/entity/MoneyChangeHistory.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/model/entity/MoneyChangeHistory.java
@@ -13,6 +13,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLRestriction;
+import radiata.database.model.BaseEntity;
 import radiata.service.payment.core.domain.model.vo.Money;
 
 @Getter
@@ -22,7 +23,7 @@ import radiata.service.payment.core.domain.model.vo.Money;
 @Builder // 빌더 패턴은 테스트 용도로만 사용
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED) // JPA 객체는 기본 생성자를 필요로 함
-public class MoneyChangeHistory {
+public class MoneyChangeHistory extends BaseEntity {
 
     @Id
     private String id;

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/model/entity/PayAccount.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/model/entity/PayAccount.java
@@ -11,6 +11,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLRestriction;
+import radiata.database.model.BaseEntity;
 import radiata.service.payment.core.domain.model.vo.Account;
 
 @Getter
@@ -20,7 +21,7 @@ import radiata.service.payment.core.domain.model.vo.Account;
 @Builder // 빌더 패턴은 테스트 용도로만 사용
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED) // JPA 객체는 기본 생성자를 필요로 함
-public class PayAccount {
+public class PayAccount extends BaseEntity {
 
     @Id
     private String id;

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/model/entity/PayUser.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/model/entity/PayUser.java
@@ -12,6 +12,7 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLRestriction;
 import radiata.common.exception.BusinessException;
 import radiata.common.message.ExceptionMessage;
+import radiata.database.model.BaseEntity;
 import radiata.service.payment.core.domain.model.vo.Money;
 
 @Getter
@@ -21,7 +22,7 @@ import radiata.service.payment.core.domain.model.vo.Money;
 @Builder // 빌더 패턴은 테스트 용도로만 사용
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED) // JPA 객체는 기본 생성자를 필요로 함
-public class PayUser {
+public class PayUser extends BaseEntity {
 
     @Id
     private String id;

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/repository/PayUserRepository.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/repository/PayUserRepository.java
@@ -1,8 +1,17 @@
 package radiata.service.payment.core.domain.repository;
 
+import java.util.Optional;
 import org.springframework.stereotype.Repository;
+import radiata.service.payment.core.domain.model.entity.PayUser;
 
 @Repository
 public interface PayUserRepository {
 
+    PayUser save(PayUser payUser);
+
+    Optional<PayUser> findById(String id);
+
+    Optional<PayUser> findByUserId(String userId);
+
+    boolean existsByUserId(String userId);
 }

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/implementation/PayUserReader.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/implementation/PayUserReader.java
@@ -1,0 +1,30 @@
+package radiata.service.payment.core.implementation;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
+import radiata.common.annotation.Implementation;
+import radiata.common.exception.BusinessException;
+import radiata.common.message.ExceptionMessage;
+import radiata.service.payment.core.domain.model.entity.PayUser;
+import radiata.service.payment.core.domain.repository.PayUserRepository;
+
+@Slf4j
+@Implementation
+@RequiredArgsConstructor
+public class PayUserReader {
+
+    private final PayUserRepository payUserRepository;
+
+    @Transactional(readOnly = true)
+    public PayUser getPayUserById(String payUserId) {
+        return payUserRepository.findById(payUserId)
+            .orElseThrow(() -> new BusinessException(ExceptionMessage.PAY_USER_NOT_FOUND));
+    }
+
+    @Transactional(readOnly = true)
+    public PayUser getPayUserByUserId(String userId) {
+        return payUserRepository.findByUserId(userId)
+            .orElseThrow(() -> new BusinessException(ExceptionMessage.PAY_USER_NOT_FOUND));
+    }
+}

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/implementation/PayUserSaver.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/implementation/PayUserSaver.java
@@ -1,0 +1,36 @@
+package radiata.service.payment.core.implementation;
+
+import com.github.ksuid.KsuidGenerator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.transaction.annotation.Transactional;
+import radiata.common.annotation.Implementation;
+import radiata.common.exception.BusinessException;
+import radiata.common.message.ExceptionMessage;
+import radiata.service.payment.core.domain.model.entity.PayUser;
+import radiata.service.payment.core.domain.repository.PayUserRepository;
+
+@Slf4j
+@Implementation
+@RequiredArgsConstructor
+public class PayUserSaver {
+
+    private final PasswordEncoder passwordEncoder;
+    private final PayUserRepository payUserRepository;
+
+    @Transactional
+    public PayUser createPayUser(String userId, String password) {
+        if (payUserRepository.existsByUserId(userId)) {
+            throw new BusinessException(ExceptionMessage.PAY_USER_DUPLICATE);
+        }
+
+        PayUser payUser = PayUser.of(
+            KsuidGenerator.generate(),
+            userId,
+            passwordEncoder.encode(password)
+        );
+
+        return payUserRepository.save(payUser);
+    }
+}

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/implementation/PayUserValidator.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/implementation/PayUserValidator.java
@@ -1,0 +1,28 @@
+package radiata.service.payment.core.implementation;
+
+import java.util.regex.Pattern;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import radiata.common.annotation.Implementation;
+import radiata.common.exception.BusinessException;
+import radiata.common.message.ExceptionMessage;
+
+@Slf4j
+@Implementation
+@RequiredArgsConstructor
+public class PayUserValidator {
+
+    private static final Pattern PASSWORD_PATTERN = Pattern.compile("^[0-9]{6}$");
+    private final PasswordEncoder passwordEncoder;
+
+    public void validatePassword(String payUserPassword, String inputPassword) {
+        if (!PASSWORD_PATTERN.matcher(inputPassword).matches()) {
+            throw new BusinessException(ExceptionMessage.INVALID_PASSWORD);
+        }
+
+        if (!passwordEncoder.matches(inputPassword, payUserPassword)) {
+            throw new BusinessException(ExceptionMessage.INVALID_PASSWORD);
+        }
+    }
+}

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/infrastructure/PayUserJpaRepository.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/infrastructure/PayUserJpaRepository.java
@@ -1,9 +1,11 @@
 package radiata.service.payment.core.infrastructure;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import radiata.service.payment.core.domain.model.entity.PayUser;
 import radiata.service.payment.core.domain.repository.PayUserRepository;
 
 public interface PayUserJpaRepository extends JpaRepository<PayUser, String>, PayUserRepository {
 
+    Optional<PayUser> findByUserId(String userId);
 }

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/service/PayUserService.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/service/PayUserService.java
@@ -1,0 +1,67 @@
+package radiata.service.payment.core.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import radiata.common.domain.payment.dto.request.PayUserAddMoneyRequestDto;
+import radiata.common.domain.payment.dto.request.PayUserCreateRequestDto;
+import radiata.common.domain.payment.dto.request.PayUserSubtractMoneyRequestDto;
+import radiata.common.domain.payment.dto.response.PayUserResponseDto;
+import radiata.service.payment.core.domain.model.entity.PayUser;
+import radiata.service.payment.core.domain.model.vo.Money;
+import radiata.service.payment.core.implementation.PayUserReader;
+import radiata.service.payment.core.implementation.PayUserSaver;
+import radiata.service.payment.core.implementation.PayUserValidator;
+import radiata.service.payment.core.service.mapper.PayUserMapper;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PayUserService {
+
+    private final PayUserSaver payUserSaver;
+    private final PayUserReader payUserReader;
+    private final PayUserMapper payUserMapper;
+    private final PayUserValidator payUserValidator;
+
+    /**
+     * 간편결제 사용자 조회
+     */
+    @Transactional(readOnly = true)
+    public PayUserResponseDto getPayUser(String userId) {
+        PayUser payUser = payUserReader.getPayUserByUserId(userId);
+        return payUserMapper.toPayUserResponseDto(payUser);
+    }
+
+    /**
+     * 간편결제 사용자 등록
+     */
+    @Transactional
+    public PayUserResponseDto signupPayUser(String userId, PayUserCreateRequestDto request) {
+        PayUser payUser = payUserSaver.createPayUser(userId, request.password());
+        return payUserMapper.toPayUserResponseDto(payUser);
+    }
+
+    /**
+     * 간편결제 사용자 잔액 추가
+     */
+    @Transactional
+    public PayUserResponseDto addMoney(String userId, PayUserAddMoneyRequestDto request) {
+        PayUser payUser = payUserReader.getPayUserByUserId(userId);
+        payUserValidator.validatePassword(payUser.getPassword(), request.password());
+        payUser.deposit(Money.of(request.amount()));
+        return payUserMapper.toPayUserResponseDto(payUser);
+    }
+
+    /**
+     * 간편결제 사용자 잔액 차감
+     */
+    @Transactional
+    public PayUserResponseDto subtractMoney(String userId, PayUserSubtractMoneyRequestDto request) {
+        PayUser payUser = payUserReader.getPayUserByUserId(userId);
+        payUserValidator.validatePassword(payUser.getPassword(), request.password());
+        payUser.withdraw(Money.of(request.amount()));
+        return payUserMapper.toPayUserResponseDto(payUser);
+    }
+}

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/service/mapper/PayUserMapper.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/service/mapper/PayUserMapper.java
@@ -1,0 +1,15 @@
+package radiata.service.payment.core.service.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingConstants.ComponentModel;
+import radiata.common.domain.payment.dto.response.PayUserResponseDto;
+import radiata.service.payment.core.domain.model.entity.PayUser;
+
+@Mapper(componentModel = ComponentModel.SPRING)
+public interface PayUserMapper {
+
+    @Mapping(target = "money", source = "balance.amount")
+    @Mapping(target = "payUserId", source = "id")
+    PayUserResponseDto toPayUserResponseDto(PayUser payUser);
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> - close #82 
> - close #81  

## 📝작업 내용

> 간편결제 사용자 API를 추가했습니다.
> 가입, 조회, 충전, 차감 구현했습니다. 

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?