### PR TITLE
[#83] Feat/order 주문 등록 - 쿠폰 서비스 Feign연동 추가

### DIFF
--- a/service/order/order-api/http/order-api.http
+++ b/service/order/order-api/http/order-api.http
@@ -1,0 +1,121 @@
+### 공통 전역 변수
+@email = "test01@email.com"
+@password = "Password12!"
+@baseUrl = http://localhost:19091
+
+### 회원 가입
+POST {{baseUrl}}/auth/sign-up
+Content-Type: application/json
+
+{
+  "username": "testUser",
+  "password": {{password}},
+  "email": {{email}},
+  "nickname": "테스트유저",
+  "phone": "010-9999-9999",
+  "roadAddress": "도로명 주소1",
+  "detailAddress": "상세 주소1",
+  "zipcode": "12345"
+}
+
+
+### 로그인
+POST {{baseUrl}}/auth/sign-in
+Content-Type: application/json
+
+{
+  "email": {{email}},
+  "password": {{password}}
+}
+
+### 토큰 사용
+@Authorization = Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIyblkzWWVybjZmMUFCWWV2MHF1UlRnMG9CRXgiLCJyb2xlIjoiQ1VTVE9NRVIiLCJpc3MiOiJ1c2VyLXNlcnZpY2UiLCJpYXQiOjE3MjkxNDM5MjUsImV4cCI6MTcyOTE0NzUyNX0.1M7uNwXUfkcqZL2ax6nfxungLSLQzhtvcyvRzL8J9higt-8cEUkne249OFpk1qDg24_Ic0Jkn9U5N1NTFVByHw
+
+
+### 브랜드 생성
+POST {{baseUrl}}/brands
+Content-Type: application/json
+Authorization: {{Authorization}}
+
+
+### 카테고리 생성
+POST {{baseUrl}}/categories
+Content-Type: application/json
+Authorization: {{Authorization}}
+
+
+### 브랜드 & 카테고리 ID
+@brandId = 2nXspusELHwmrDj0RG71XIVwMQa
+@categoryId = 2nXsqNjcYqFOJL69XI1RgGXYyKJ
+
+
+### 상품 등록
+POST {{baseUrl}}/goods
+Content-Type: application/json
+Authorization: {{Authorization}}
+
+{
+  "brandId":{{brandId}},
+  "categoryId":{{categoryId}},
+  "name":"반팔티",
+  "price":15000,
+  "discountAmount":10,
+  "stock": 100,
+  "gender":"ALL",
+  "color":"BLUE",
+  "size":"LARGE"
+}
+
+
+### 쿠폰 생성
+POST {{baseUrl}}/coupons
+Content-Type: application/json
+Authorization: {{Authorization}}
+
+{
+  "title": "Coupon Amount1",
+  "couponType": "FIRST_COME_FIRST_SERVED",
+  "couponSaleType": "AMOUNT",
+  "totalQuantity": 100,
+  "discountAmount": 5000,
+  "discountRate": null,
+  "minAvailableAmount": 20000,
+  "issueStartDate": "2024-10-01T00:00:00",
+  "issueEndDate": "2024-10-31T23:59:59"
+}
+
+### 쿠폰ID
+@couponId = 2nXtvTVxJFuuKosj6KtOtVkQGG0
+
+### 쿠폰 발급
+POST {{baseUrl}}/coupons/{{couponId}}/issue
+Content-Type: application/json
+Authorization: {{Authorization}}
+
+
+### 주문 등록
+POST {{baseUrl}}/orders
+Content-Type: application/json
+Authorization: {{Authorization}}
+
+{
+  "address": "address-01",
+  "comment": "comment-01",
+  "point": 0,
+  "itemList": [
+    {
+      "productId": "2nXt9CSsHsWe4GgPEHXVoiAwB0Z",
+      "timeSaleProductId": null,
+      "couponIssuedId": "2nYLlmu5q41qt8Juc3PLmjQornL",
+      "quantity": 10,
+      "unitPrice": "30000"
+    },
+    {
+      "productId": "2nXtdCF4D3PguWvp03pPDa4Yjrp",
+      "timeSaleProductId": null,
+      "couponIssuedId": "2nYLhcM29HC4dH4BKypBS2Wf02I",
+      "quantity": 5,
+      "unitPrice": "15000"
+    }
+  ]
+}

--- a/service/order/order-api/src/main/resources/application.yml
+++ b/service/order/order-api/src/main/resources/application.yml
@@ -5,6 +5,10 @@ spring:
     import: classpath:application-database.yml
   profiles:
     default: dev
+  cloud:
+    openfeign:
+      okhttp:
+        enabled: true
 
 server:
   port: 8085

--- a/service/order/order-core/build.gradle
+++ b/service/order/order-core/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
     implementation 'org.springframework.kafka:spring-kafka'
+    implementation 'io.github.openfeign:feign-okhttp:11.8'
 
     /* 테스트 */
     testImplementation 'com.h2database:h2:2.1.214'

--- a/service/order/order-core/src/main/java/radiata/service/order/core/domain/model/entity/OrderItem.java
+++ b/service/order/order-core/src/main/java/radiata/service/order/core/domain/model/entity/OrderItem.java
@@ -41,9 +41,6 @@ public class OrderItem extends BaseEntity {
     @Column(nullable = false)
     private Integer quantity;
 
-//    @Column(nullable = false)
-//    private size;
-
     @Column(nullable = false)
     private Integer unitPrice;
 
@@ -69,7 +66,25 @@ public class OrderItem extends BaseEntity {
             .couponIssuedId(couponIssuedId)
             .quantity(quantity)
             .unitPrice(unitPrice)
-            .paymentPrice(unitPrice * quantity)
             .build();
+    }
+
+    // 금액 지정
+    public int setPrice(String saleType, Integer discountValue) {
+        int price = this.unitPrice * this.quantity;
+        if (saleType == null || discountValue == null) {
+            return this.paymentPrice = price;
+        }
+
+        return calculateDiscount(price, saleType, discountValue);
+    }
+
+    // 할인 금액, 율 계산
+    private int calculateDiscount(int price, String saleType, Integer discountValue) {
+        double finalPrice = saleType.equals("AMOUNT")
+            ? price - discountValue                 // 금액 할인
+            : price * (1 - discountValue / 100.0);  // 할인율 적용
+
+        return this.paymentPrice = (int) finalPrice;
     }
 }

--- a/service/order/order-core/src/main/java/radiata/service/order/core/service/client/CouponIssueClient.java
+++ b/service/order/order-core/src/main/java/radiata/service/order/core/service/client/CouponIssueClient.java
@@ -1,21 +1,16 @@
 package radiata.service.order.core.service.client;
 
 import org.springframework.cloud.openfeign.FeignClient;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
-import radiata.common.response.CommonResponse;
+import radiata.common.domain.coupon.dto.response.CouponIssueResponseDto;
+import radiata.common.response.SuccessResponse;
 
 @FeignClient(name = "coupon-service")
 public interface CouponIssueClient {
 
-    @GetMapping("/couponissues/{couponIssueId}")
-    ResponseEntity<? extends CommonResponse> getCouponIssue(@PathVariable String couponIssueId,
-        @RequestHeader("X-UserId") String userId);
-
     @PatchMapping("/couponissues/{couponIssueId}")
-    ResponseEntity<? extends CommonResponse> useCouponIssue(@PathVariable String couponIssueId,
+    SuccessResponse<CouponIssueResponseDto> useCouponIssue(@PathVariable String couponIssueId,
         @RequestHeader("X-UserId") String userId);
 }

--- a/service/order/order-core/src/main/java/radiata/service/order/core/service/client/CouponIssueClient.java
+++ b/service/order/order-core/src/main/java/radiata/service/order/core/service/client/CouponIssueClient.java
@@ -1,10 +1,12 @@
 package radiata.service.order.core.service.client;
 
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
 import radiata.common.domain.coupon.dto.response.CouponIssueResponseDto;
+import radiata.common.domain.coupon.dto.response.CouponResponseDto;
 import radiata.common.response.SuccessResponse;
 
 @FeignClient(name = "coupon-service")
@@ -13,4 +15,7 @@ public interface CouponIssueClient {
     @PatchMapping("/couponissues/{couponIssueId}")
     SuccessResponse<CouponIssueResponseDto> useCouponIssue(@PathVariable String couponIssueId,
         @RequestHeader("X-UserId") String userId);
+
+    @GetMapping("/coupons/{couponId}")
+    SuccessResponse<CouponResponseDto> getCouponType(@PathVariable String couponId);
 }

--- a/service/order/order-core/src/test/java/radiata/service/order/core/domain/model/entity/OrderTest.java
+++ b/service/order/order-core/src/test/java/radiata/service/order/core/domain/model/entity/OrderTest.java
@@ -63,7 +63,6 @@ class OrderTest {
         assertThat(orderItem.getCouponIssuedId()).isEqualTo("couponIssuedId-01");
         assertThat(orderItem.getQuantity()).isEqualTo(5);
         assertThat(orderItem.getUnitPrice()).isEqualTo(10000);
-        assertThat(orderItem.getPaymentPrice()).isEqualTo(50000);
     }
 
     @Test


### PR DESCRIPTION
## #️⃣연관된 이슈

> - closed: #83 

## 📝작업 내용

> 쿠폰 쪽과 FeignClient 연동했습니다.
1) 쿠폰 상태 값 변경 요청
2) 쿠폰 정보 확인 -> 쿠폰 타입과 타입에 따른 할인율 or 할인 금액을 가져와야해서 사용했습니다.
-> 쿠폰 상태 변경에서 온 CouponIssueResponseDto에는 Coupon정보가 없어서 2번 로직 추가했습니다!
3) 가져온 할인 종류에 따라서 할인율 or 할인금액을 계산해서 상품 주문금액에 설정되도록 계산로직 추가했습니다.

### 스크린샷 (선택)

### 현재 무신사 기준 상품에 쿠폰 할인 적용된 사례 사진 
<img width="602" alt="스크린샷 2024-10-17 오전 12 17 49" src="https://github.com/user-attachments/assets/4d41c8f0-c603-4050-94ff-854b4989383f">
<img width="668" alt="스크린샷 2024-10-17 오전 12 17 56" src="https://github.com/user-attachments/assets/561ac65a-322b-4563-9230-96c10116a166">
<br>
</br>

### 구현한 결과 동일 가격 & 쿠폰 할인율 테스트 결과
<img width="553" alt="스크린샷 2024-10-17 오전 12 19 57" src="https://github.com/user-attachments/assets/f1b6cde7-17c4-4e4f-a514-1b64b2a9160a">


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> OrderItemService 클래스에서 processOrderItem이라는 메서드로 굉장히 크고 길게.. 작성하고 있는데요.. 
코드를 쪼깰 좋을 방법이 있으시다면 공유 부탁드립니다...!! 흑흑