### PR TITLE
[#87] feat(deploy): Graceful shutdown 적용

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -94,14 +94,6 @@ jobs:
           script: |
             echo ${{ env.DOCKER_HUB_TOKEN }} | docker login -u ${{ env.DOCKER_HUB_USERNAME }} --password-stdin
             docker compose -f ./docker-compose-deploy.yml down
-            docker rm -f autumn-user-server
-            docker rm -f autumn-coupon-server
-            docker rm -f autumn-timesale-server
-            docker rm -f autumn-order-server
-            docker rm -f autumn-brand-server
-            docker rm -f autumn-payment-server
-            docker rm -f autumn-gateway-server
-            docker rm -f autumn-eureka-server
             docker pull ${{ env.DOCKER_HUB_USERNAME }}/autumn-user-server:latest
             docker pull ${{ env.DOCKER_HUB_USERNAME }}/autumn-coupon-server:latest
             docker pull ${{ env.DOCKER_HUB_USERNAME }}/autumn-timesale-server:latest

--- a/docker-compose-deploy.yml
+++ b/docker-compose-deploy.yml
@@ -8,6 +8,8 @@ services:
         - FILE_DIRECTORY=service/payment/payment-api
     ports:
       - "8080:8080"
+    stop_grace_period: 15s
+    stop_signal: SIGTERM
     depends_on:
       - eureka-server
 
@@ -20,6 +22,8 @@ services:
         - FILE_DIRECTORY=service/order/order-api
     ports:
       - "8085:8085"
+    stop_grace_period: 15s
+    stop_signal: SIGTERM
     depends_on:
       - eureka-server
 
@@ -32,6 +36,8 @@ services:
         - FILE_DIRECTORY=service/brand/brand-api
     ports:
       - "8484:8484"
+    stop_grace_period: 15s
+    stop_signal: SIGTERM
     depends_on:
       - eureka-server
 
@@ -44,6 +50,8 @@ services:
         - FILE_DIRECTORY=service/coupon/coupon-api
     ports:
       - "8081:8081"
+    stop_grace_period: 15s
+    stop_signal: SIGTERM
     depends_on:
       - eureka-server
 
@@ -56,6 +64,8 @@ services:
         - FILE_DIRECTORY=service/timesale/timesale-api
     ports:
       - "8082:8082"
+    stop_grace_period: 15s
+    stop_signal: SIGTERM
     depends_on:
       - eureka-server
 
@@ -68,6 +78,8 @@ services:
         - FILE_DIRECTORY=service/user/user-api
     ports:
       - "8083:8083"
+    stop_grace_period: 15s
+    stop_signal: SIGTERM
     depends_on:
       - eureka-server
 
@@ -80,6 +92,8 @@ services:
         - FILE_DIRECTORY=service/gateway/gateway-core
     ports:
       - "19091:19091"
+    stop_grace_period: 17s
+    stop_signal: SIGTERM
     depends_on:
       - eureka-server
 
@@ -92,9 +106,5 @@ services:
         - FILE_DIRECTORY=service/eureka/eureka-core
     ports:
       - "19090:19090"
-
-volumes:
-  postgres_main_volume:
-  postgres_batch_volume:
-  redis_volume:
-
+    stop_grace_period: 15s
+    stop_signal: SIGTERM

--- a/service/brand/brand-api/src/main/resources/application.yml
+++ b/service/brand/brand-api/src/main/resources/application.yml
@@ -3,8 +3,11 @@ spring:
     name: brand-service
   config:
     import: classpath:application-database.yml
+  lifecycle:
+    timeout-per-shutdown-phase: 10s
 
 server:
+  shutdown: graceful  # 애플리케이션 종료 시 정상 종료 (Graceful Shutdown)
   port: 8484
 
 eureka:

--- a/service/coupon/coupon-api/src/main/resources/application-api.yml
+++ b/service/coupon/coupon-api/src/main/resources/application-api.yml
@@ -3,8 +3,11 @@ spring:
     import: classpath:application-database.yml
   application:
     name: coupon-service
+  lifecycle:
+    timeout-per-shutdown-phase: 10s
 
 server:
+  shutdown: graceful  # 애플리케이션 종료 시 정상 종료 (Graceful Shutdown)
   port: 8081
 
 eureka:

--- a/service/eureka/eureka-core/src/main/resources/application.yml
+++ b/service/eureka/eureka-core/src/main/resources/application.yml
@@ -1,8 +1,13 @@
 spring:
   application:
     name: eureka-server
+  lifecycle:
+    timeout-per-shutdown-phase: 10s
+
 server:
+  shutdown: graceful  # 애플리케이션 종료 시 정상 종료 (Graceful Shutdown)
   port: 19090
+
 eureka:
   client:
     register-with-eureka: false

--- a/service/gateway/gateway-core/src/main/resources/application.yml
+++ b/service/gateway/gateway-core/src/main/resources/application.yml
@@ -1,5 +1,6 @@
 server:
   port: 19091
+  shutdown: graceful  # 애플리케이션 종료 시 정상 종료 (Graceful Shutdown)
 spring:
   application:
     name: gateway-service
@@ -13,6 +14,8 @@ spring:
       filter:
         circuit-breaker:
           enabled:
+  lifecycle:
+    timeout-per-shutdown-phase: 12s
 
 eureka:
   client:

--- a/service/order/order-api/src/main/resources/application.yml
+++ b/service/order/order-api/src/main/resources/application.yml
@@ -5,8 +5,11 @@ spring:
     import: classpath:application-database.yml
   profiles:
     default: dev
+  lifecycle:
+    timeout-per-shutdown-phase: 10s
 
 server:
+  shutdown: graceful  # 애플리케이션 종료 시 정상 종료 (Graceful Shutdown)
   port: 8085
 
 eureka:

--- a/service/payment/payment-api/src/main/resources/application.yml
+++ b/service/payment/payment-api/src/main/resources/application.yml
@@ -5,6 +5,11 @@ spring:
     import: classpath:application-database.yml # database 속성 가져오기용
   profiles:
     default: dev
+  lifecycle:
+    timeout-per-shutdown-phase: 10s
+
+server:
+  shutdown: graceful  # 애플리케이션 종료 시 정상 종료 (Graceful Shutdown)
 
 eureka:
   client:

--- a/service/timesale/timesale-api/src/main/resources/application-timesale-api.yml
+++ b/service/timesale/timesale-api/src/main/resources/application-timesale-api.yml
@@ -1,8 +1,11 @@
 spring:
   application:
     name: timesale-service
+  lifecycle:
+    timeout-per-shutdown-phase: 10s
 
 server:
+  shutdown: graceful  # 애플리케이션 종료 시 정상 종료 (Graceful Shutdown)
   port: 8082
 
 eureka:

--- a/service/user/user-api/src/main/resources/application.yml
+++ b/service/user/user-api/src/main/resources/application.yml
@@ -3,8 +3,11 @@ spring:
     name: user-service
   config:
     import: classpath:application-database.yml
+  lifecycle:
+    timeout-per-shutdown-phase: 10s
 
 server:
+  shutdown: graceful  # 애플리케이션 종료 시 정상 종료 (Graceful Shutdown)
   port: 8083
 
 eureka:


### PR DESCRIPTION
## #️⃣연관된 이슈

> - close #87 

## 📝작업 내용

> 스프링 및 도커 컴포즈에 Graceful shutdown을 적용했습니다. 
> 스프링에는 종료 시 현재 요청을 다 받고 종료하도록 했고, 최대 유지 시간을 10초로 설정하여 계속 실행되지 않도록 했습니다.
> 도커 컴포즈에서는 컨테이너 종료 시 정상 종료 시그널을 보내되, 최대 유지 시간을 15초로 설정하여 계속 실행되지 않도록 했습니다.
> 게이트웨이의 경우에는 +2초씩 더해주었습니다. 

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>