### PR TITLE
[#86] feat(payment): 간편결제 결제 API 추가 

### DIFF
--- a/common/src/main/java/radiata/common/domain/payment/constant/Bank.java
+++ b/common/src/main/java/radiata/common/domain/payment/constant/Bank.java
@@ -1,4 +1,4 @@
-package radiata.service.payment.core.domain.model.vo;
+package radiata.common.domain.payment.constant;
 
 import java.util.Optional;
 import java.util.stream.Stream;

--- a/common/src/main/java/radiata/common/domain/payment/constant/FirmBankingRequestStatus.java
+++ b/common/src/main/java/radiata/common/domain/payment/constant/FirmBankingRequestStatus.java
@@ -1,4 +1,4 @@
-package radiata.service.payment.core.domain.model.vo;
+package radiata.common.domain.payment.constant;
 
 public enum FirmBankingRequestStatus {
     SUCCESS, FAIL

--- a/common/src/main/java/radiata/common/domain/payment/constant/PaymentStatus.java
+++ b/common/src/main/java/radiata/common/domain/payment/constant/PaymentStatus.java
@@ -1,4 +1,4 @@
-package radiata.service.payment.core.domain.model.vo;
+package radiata.common.domain.payment.constant;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/common/src/main/java/radiata/common/domain/payment/constant/PaymentType.java
+++ b/common/src/main/java/radiata/common/domain/payment/constant/PaymentType.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum PaymentType {
     TOSS_PAYMENTS("토스페이먼츠"),
-    RADIATA_PAY("간편결제");
+    EASY_PAY("간편결제");
 
     private final String title;
 }

--- a/common/src/main/java/radiata/common/domain/payment/constant/PaymentType.java
+++ b/common/src/main/java/radiata/common/domain/payment/constant/PaymentType.java
@@ -1,4 +1,4 @@
-package radiata.service.payment.core.domain.model.vo;
+package radiata.common.domain.payment.constant;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/common/src/main/java/radiata/common/domain/payment/dto/request/EasyPayCreateRequestDto.java
+++ b/common/src/main/java/radiata/common/domain/payment/dto/request/EasyPayCreateRequestDto.java
@@ -1,0 +1,9 @@
+package radiata.common.domain.payment.dto.request;
+
+public record EasyPayCreateRequestDto(
+    String userId,
+    Long amount,
+    String password
+) {
+
+}

--- a/common/src/main/java/radiata/common/domain/payment/dto/request/EasyPayCreateRequestDto.java
+++ b/common/src/main/java/radiata/common/domain/payment/dto/request/EasyPayCreateRequestDto.java
@@ -1,8 +1,17 @@
 package radiata.common.domain.payment.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
 public record EasyPayCreateRequestDto(
+
+    @NotBlank(message = "userId는 필수입니다.")
     String userId,
+
+    @NotBlank(message = "orderId는 필수입니다.")
     Long amount,
+
+    @Pattern(regexp = "^[0-9]{6}$", message = "password는 6자리 숫자여야 합니다.")
     String password
 ) {
 

--- a/common/src/main/java/radiata/common/domain/payment/dto/request/EasyPayCreateRequestDto.java
+++ b/common/src/main/java/radiata/common/domain/payment/dto/request/EasyPayCreateRequestDto.java
@@ -2,13 +2,14 @@ package radiata.common.domain.payment.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.PositiveOrZero;
 
 public record EasyPayCreateRequestDto(
 
     @NotBlank(message = "userId는 필수입니다.")
     String userId,
 
-    @NotBlank(message = "orderId는 필수입니다.")
+    @PositiveOrZero(message = "amount는 0 이상이어야 합니다.")
     Long amount,
 
     @Pattern(regexp = "^[0-9]{6}$", message = "password는 6자리 숫자여야 합니다.")

--- a/common/src/main/java/radiata/common/domain/payment/dto/request/TossPaymentCreateRequestDto.java
+++ b/common/src/main/java/radiata/common/domain/payment/dto/request/TossPaymentCreateRequestDto.java
@@ -1,9 +1,22 @@
 package radiata.common.domain.payment.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+
 public record TossPaymentCreateRequestDto(
+
+    @NotBlank(message = "userId는 필수입니다.")
     String userId,
+
+    @NotBlank(message = "orderId는 필수입니다.")
     String orderId,
+
+    @NotBlank(message = "paymentKey는 필수입니다.")
     String paymentKey,
+
+    @NotNull(message = "amount는 필수입니다.")
+    @PositiveOrZero(message = "amount는 0 이상이어야 합니다.")
     Long amount
 ) {
 

--- a/common/src/main/java/radiata/common/domain/payment/dto/response/PaymentCreateResponseDto.java
+++ b/common/src/main/java/radiata/common/domain/payment/dto/response/PaymentCreateResponseDto.java
@@ -1,6 +1,6 @@
 package radiata.common.domain.payment.dto.response;
 
-public record TossPaymentCreateResponseDto(
+public record PaymentCreateResponseDto(
     Boolean isPaymentSuccess,
     String paymentId
 ) {

--- a/service/gateway/gateway-core/src/main/java/radiata/service/gateway/core/config/GatewayConfig.java
+++ b/service/gateway/gateway-core/src/main/java/radiata/service/gateway/core/config/GatewayConfig.java
@@ -27,7 +27,7 @@ public class GatewayConfig {
             .route("timesale-service", r -> r.path("/timesales/**", "/timesale-products/**", "/products/**")
                 .filters(f -> applyCommonFilters(f, "timesale-service"))
                 .uri("lb://timesale-service"))
-            .route("payment-service", r -> r.path("/payments/**")
+            .route("payment-service", r -> r.path("/payments/**", "/payusers/**")
                 .filters(f -> applyCommonFilters(f, "payment-service"))
                 .uri("lb://payment-service"))
             .route("coupon-service", r -> r.path("/coupons/**", "/couponissues/**")

--- a/service/order/order-core/src/main/java/radiata/service/order/core/domain/model/entity/Order.java
+++ b/service/order/order-core/src/main/java/radiata/service/order/core/domain/model/entity/Order.java
@@ -16,9 +16,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLRestriction;
+import radiata.common.domain.payment.constant.PaymentType;
 import radiata.database.model.BaseEntity;
 import radiata.service.order.core.domain.model.constant.OrderStatus;
-import radiata.service.payment.core.domain.model.vo.PaymentType;
 
 @Entity
 @Table(name = "r_order")

--- a/service/order/order-core/src/main/java/radiata/service/order/core/service/client/PaymentClient.java
+++ b/service/order/order-core/src/main/java/radiata/service/order/core/service/client/PaymentClient.java
@@ -4,12 +4,12 @@ import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import radiata.common.domain.payment.dto.request.TossPaymentCreateRequestDto;
-import radiata.common.domain.payment.dto.response.TossPaymentCreateResponseDto;
+import radiata.common.domain.payment.dto.response.PaymentCreateResponseDto;
 import radiata.common.response.SuccessResponse;
 
 @FeignClient(name = "payment-service")
 public interface PaymentClient {
 
     @PostMapping("/payments/toss")
-    SuccessResponse<TossPaymentCreateResponseDto> requestTossPayment(@RequestBody TossPaymentCreateRequestDto request);
+    SuccessResponse<PaymentCreateResponseDto> requestTossPayment(@RequestBody TossPaymentCreateRequestDto request);
 }

--- a/service/payment/payment-api/http/easypay-scenario.http
+++ b/service/payment/payment-api/http/easypay-scenario.http
@@ -1,0 +1,19 @@
+### 간편결제 유저 충전금 충전
+PATCH http://localhost:8080/payusers/money/add
+Content-Type: application/json
+X-Userid: 2nVDCU4ILPYK6ezjTUNqAHXK3jQ
+
+{
+  "password": "123456",
+  "amount": 1000
+}
+
+### 간편결제 요청
+POST http://localhost:8080/payments/easypay
+Content-Type: application/json
+
+{
+  "userId": "2nVDCU4ILPYK6ezjTUNqAHXK3jQ",
+  "amount": 1000,
+  "password": "123456"
+}

--- a/service/payment/payment-api/src/main/java/radiata/service/payment/api/presentation/PaymentController.java
+++ b/service/payment/payment-api/src/main/java/radiata/service/payment/api/presentation/PaymentController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import radiata.common.domain.payment.dto.request.TossPaymentCreateRequestDto;
-import radiata.common.domain.payment.dto.response.TossPaymentCreateResponseDto;
+import radiata.common.domain.payment.dto.response.PaymentCreateResponseDto;
 import radiata.common.message.SuccessMessage;
 import radiata.common.response.SuccessResponse;
 import radiata.service.payment.core.service.TossPaymentService;
@@ -23,7 +23,7 @@ public class PaymentController {
     private final TossPaymentService tossPaymentService;
 
     @PostMapping("/toss")
-    public SuccessResponse<TossPaymentCreateResponseDto> requestTossPayment(
+    public SuccessResponse<PaymentCreateResponseDto> requestTossPayment(
         @RequestBody TossPaymentCreateRequestDto request
     ) {
         return SuccessResponse.success(SuccessMessage.OK.getMessage(), tossPaymentService.requestTossPayment(request));

--- a/service/payment/payment-api/src/main/java/radiata/service/payment/api/presentation/PaymentController.java
+++ b/service/payment/payment-api/src/main/java/radiata/service/payment/api/presentation/PaymentController.java
@@ -3,14 +3,17 @@ package radiata.service.payment.api.presentation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import radiata.common.domain.payment.dto.request.EasyPayCreateRequestDto;
 import radiata.common.domain.payment.dto.request.TossPaymentCreateRequestDto;
 import radiata.common.domain.payment.dto.response.PaymentCreateResponseDto;
 import radiata.common.message.SuccessMessage;
 import radiata.common.response.SuccessResponse;
+import radiata.service.payment.core.service.EasyPayPaymentService;
 import radiata.service.payment.core.service.TossPaymentService;
 
 @Tag(name = "결제", description = "결제 API")
@@ -21,11 +24,20 @@ import radiata.service.payment.core.service.TossPaymentService;
 public class PaymentController {
 
     private final TossPaymentService tossPaymentService;
+    private final EasyPayPaymentService easyPayPaymentService;
 
     @PostMapping("/toss")
     public SuccessResponse<PaymentCreateResponseDto> requestTossPayment(
-        @RequestBody TossPaymentCreateRequestDto request
+        @Validated @RequestBody TossPaymentCreateRequestDto request
     ) {
         return SuccessResponse.success(SuccessMessage.OK.getMessage(), tossPaymentService.requestTossPayment(request));
+    }
+
+    @PostMapping("/easypay")
+    public SuccessResponse<PaymentCreateResponseDto> requestEasyPay(
+        @Validated @RequestBody EasyPayCreateRequestDto request
+    ) {
+        PaymentCreateResponseDto response = easyPayPaymentService.requestTossPayment(request);
+        return SuccessResponse.success(SuccessMessage.OK.getMessage(), response);
     }
 }

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/model/entity/FirmBankingRequestHistory.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/model/entity/FirmBankingRequestHistory.java
@@ -15,9 +15,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLRestriction;
+import radiata.common.domain.payment.constant.FirmBankingRequestStatus;
 import radiata.database.model.BaseEntity;
 import radiata.service.payment.core.domain.model.vo.Account;
-import radiata.service.payment.core.domain.model.vo.FirmBankingRequestStatus;
 import radiata.service.payment.core.domain.model.vo.Money;
 
 @Getter

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/model/entity/Payment.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/model/entity/Payment.java
@@ -13,10 +13,10 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLRestriction;
+import radiata.common.domain.payment.constant.PaymentStatus;
+import radiata.common.domain.payment.constant.PaymentType;
 import radiata.database.model.BaseEntity;
 import radiata.service.payment.core.domain.model.vo.Money;
-import radiata.service.payment.core.domain.model.vo.PaymentStatus;
-import radiata.service.payment.core.domain.model.vo.PaymentType;
 
 @Getter
 @Entity

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/model/vo/Account.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/domain/model/vo/Account.java
@@ -8,6 +8,7 @@ import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import radiata.common.domain.payment.constant.Bank;
 
 @Getter
 @Embeddable // JPA 값객체 어노테이션

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/implementation/PaymentSaver.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/implementation/PaymentSaver.java
@@ -28,4 +28,16 @@ public class PaymentSaver {
 
         return paymentRepository.save(payment);
     }
+
+    @Transactional
+    public Payment createEasyPay(String userId, Long amount) {
+        Payment payment = Payment.of(
+            KsuidGenerator.generate(),
+            userId,
+            KsuidGenerator.generate(),
+            Money.of(amount),
+            PaymentType.EASY_PAY);
+
+        return paymentRepository.save(payment);
+    }
 }

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/implementation/PaymentSaver.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/implementation/PaymentSaver.java
@@ -5,9 +5,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
 import radiata.common.annotation.Implementation;
+import radiata.common.domain.payment.constant.PaymentType;
 import radiata.service.payment.core.domain.model.entity.Payment;
 import radiata.service.payment.core.domain.model.vo.Money;
-import radiata.service.payment.core.domain.model.vo.PaymentType;
 import radiata.service.payment.core.domain.repository.PaymentRepository;
 
 @Slf4j

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/service/EasyPayPaymentService.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/service/EasyPayPaymentService.java
@@ -1,0 +1,43 @@
+package radiata.service.payment.core.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import radiata.common.domain.payment.constant.PaymentStatus;
+import radiata.common.domain.payment.dto.request.EasyPayCreateRequestDto;
+import radiata.common.domain.payment.dto.response.PaymentCreateResponseDto;
+import radiata.service.payment.core.domain.model.entity.PayUser;
+import radiata.service.payment.core.domain.model.entity.Payment;
+import radiata.service.payment.core.implementation.PayUserReader;
+import radiata.service.payment.core.implementation.PayUserValidator;
+import radiata.service.payment.core.implementation.PaymentRequester;
+import radiata.service.payment.core.implementation.PaymentSaver;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EasyPayPaymentService {
+
+    private final PaymentSaver paymentSaver;
+    private final PayUserReader payUserReader;
+    private final PayUserValidator payUserValidator;
+    private final PaymentRequester paymentRequester;
+
+    /**
+     * 간편결제 요청
+     */
+    @Transactional
+    public PaymentCreateResponseDto requestTossPayment(EasyPayCreateRequestDto request) {
+        // 간편결제 유저 조회
+        PayUser payUser = payUserReader.getPayUserByUserId(request.userId());
+        // 간편결제 유저 비밀번호 검증
+        payUserValidator.validatePassword(payUser.getPassword(), request.password());
+        // 결제 생성
+        Payment payment = paymentSaver.createEasyPay(request.userId(), request.amount());
+        // 결제 요청
+        paymentRequester.requestEasyPay(payment, payUser);
+
+        return new PaymentCreateResponseDto(payment.getStatus().equals(PaymentStatus.APPROVED), payment.getId());
+    }
+}

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/service/TossPaymentService.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/service/TossPaymentService.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import radiata.common.domain.payment.constant.PaymentStatus;
 import radiata.common.domain.payment.dto.request.TossPaymentCreateRequestDto;
-import radiata.common.domain.payment.dto.response.TossPaymentCreateResponseDto;
+import radiata.common.domain.payment.dto.response.PaymentCreateResponseDto;
 import radiata.service.payment.core.domain.model.entity.Payment;
 import radiata.service.payment.core.implementation.PaymentRequester;
 import radiata.service.payment.core.implementation.PaymentSaver;
@@ -20,12 +20,12 @@ public class TossPaymentService {
     private final PaymentRequester paymentRequester;
 
     @Transactional
-    public TossPaymentCreateResponseDto requestTossPayment(TossPaymentCreateRequestDto request) {
+    public PaymentCreateResponseDto requestTossPayment(TossPaymentCreateRequestDto request) {
         // 결제 생성
         Payment payment = paymentSaver.createTossPayment(request.userId(), request.paymentKey(), request.amount());
         // 토스 결제 요청
         paymentRequester.requestTossPayment(payment, request.orderId());
 
-        return new TossPaymentCreateResponseDto(payment.getStatus().equals(PaymentStatus.APPROVED), payment.getId());
+        return new PaymentCreateResponseDto(payment.getStatus().equals(PaymentStatus.APPROVED), payment.getId());
     }
 }

--- a/service/payment/payment-core/src/main/java/radiata/service/payment/core/service/TossPaymentService.java
+++ b/service/payment/payment-core/src/main/java/radiata/service/payment/core/service/TossPaymentService.java
@@ -4,10 +4,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import radiata.common.domain.payment.constant.PaymentStatus;
 import radiata.common.domain.payment.dto.request.TossPaymentCreateRequestDto;
 import radiata.common.domain.payment.dto.response.TossPaymentCreateResponseDto;
 import radiata.service.payment.core.domain.model.entity.Payment;
-import radiata.service.payment.core.domain.model.vo.PaymentStatus;
 import radiata.service.payment.core.implementation.PaymentRequester;
 import radiata.service.payment.core.implementation.PaymentSaver;
 

--- a/service/payment/payment-core/src/test/java/radiata/service/payment/core/domain/model/entity/FirmBankingRequestHistoryTest.java
+++ b/service/payment/payment-core/src/test/java/radiata/service/payment/core/domain/model/entity/FirmBankingRequestHistoryTest.java
@@ -6,9 +6,9 @@ import com.github.ksuid.Ksuid;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import radiata.common.domain.payment.constant.Bank;
+import radiata.common.domain.payment.constant.FirmBankingRequestStatus;
 import radiata.service.payment.core.domain.model.vo.Account;
-import radiata.service.payment.core.domain.model.vo.Bank;
-import radiata.service.payment.core.domain.model.vo.FirmBankingRequestStatus;
 import radiata.service.payment.core.domain.model.vo.Money;
 
 @DisplayName("FirmBankingRequestHistory 엔티티 테스트")

--- a/service/payment/payment-core/src/test/java/radiata/service/payment/core/domain/model/entity/PayAccountTest.java
+++ b/service/payment/payment-core/src/test/java/radiata/service/payment/core/domain/model/entity/PayAccountTest.java
@@ -7,8 +7,8 @@ import com.github.ksuid.Ksuid;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import radiata.common.domain.payment.constant.Bank;
 import radiata.service.payment.core.domain.model.vo.Account;
-import radiata.service.payment.core.domain.model.vo.Bank;
 
 @DisplayName("Account 엔티티 테스트")
 class PayAccountTest {

--- a/service/payment/payment-core/src/test/java/radiata/service/payment/core/domain/model/entity/PaymentTest.java
+++ b/service/payment/payment-core/src/test/java/radiata/service/payment/core/domain/model/entity/PaymentTest.java
@@ -49,7 +49,7 @@ class PaymentTest {
             "user01",
             "transaction01",
             Money.of(1000),
-            PaymentType.RADIATA_PAY);
+            PaymentType.EASY_PAY);
 
         // then
         assertThat(payPayment.getId()).isNotBlank();
@@ -57,7 +57,7 @@ class PaymentTest {
         assertThat(payPayment.getTransactionId()).isEqualTo("transaction01");
         assertThat(payPayment.getAmount()).isEqualTo(Money.of(1000));
         assertThat(payPayment.getStatus()).isEqualTo(PaymentStatus.PENDING);
-        assertThat(payPayment.getType()).isEqualTo(PaymentType.RADIATA_PAY);
+        assertThat(payPayment.getType()).isEqualTo(PaymentType.EASY_PAY);
     }
 
     @Test

--- a/service/payment/payment-core/src/test/java/radiata/service/payment/core/domain/model/entity/PaymentTest.java
+++ b/service/payment/payment-core/src/test/java/radiata/service/payment/core/domain/model/entity/PaymentTest.java
@@ -9,9 +9,9 @@ import org.assertj.core.data.TemporalUnitWithinOffset;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import radiata.common.domain.payment.constant.PaymentStatus;
+import radiata.common.domain.payment.constant.PaymentType;
 import radiata.service.payment.core.domain.model.vo.Money;
-import radiata.service.payment.core.domain.model.vo.PaymentStatus;
-import radiata.service.payment.core.domain.model.vo.PaymentType;
 
 @DisplayName("Payment 엔티티 테스트")
 class PaymentTest {

--- a/service/payment/payment-core/src/test/java/radiata/service/payment/core/domain/model/vo/AccountTest.java
+++ b/service/payment/payment-core/src/test/java/radiata/service/payment/core/domain/model/vo/AccountTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import radiata.common.domain.payment.constant.Bank;
 
 @DisplayName("Account VO 테스트")
 class AccountTest {

--- a/service/payment/payment-core/src/test/java/radiata/service/payment/core/domain/model/vo/BankTest.java
+++ b/service/payment/payment-core/src/test/java/radiata/service/payment/core/domain/model/vo/BankTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import radiata.common.domain.payment.constant.Bank;
 
 @DisplayName("Bank VO 테스트")
 class BankTest {

--- a/service/payment/payment-core/src/test/java/radiata/service/payment/core/implementation/PaymentRequesterTest.java
+++ b/service/payment/payment-core/src/test/java/radiata/service/payment/core/implementation/PaymentRequesterTest.java
@@ -16,10 +16,10 @@ import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.client.RestTemplate;
+import radiata.common.domain.payment.constant.PaymentStatus;
+import radiata.common.domain.payment.constant.PaymentType;
 import radiata.service.payment.core.domain.model.entity.Payment;
 import radiata.service.payment.core.domain.model.vo.Money;
-import radiata.service.payment.core.domain.model.vo.PaymentStatus;
-import radiata.service.payment.core.domain.model.vo.PaymentType;
 
 @DisplayName("PaymentRequester 테스트")
 @ExtendWith(MockitoExtension.class)

--- a/service/payment/payment-core/src/test/java/radiata/service/payment/core/implementation/PaymentSaverTest.java
+++ b/service/payment/payment-core/src/test/java/radiata/service/payment/core/implementation/PaymentSaverTest.java
@@ -11,9 +11,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import radiata.common.domain.payment.constant.PaymentType;
 import radiata.service.payment.core.domain.model.entity.Payment;
 import radiata.service.payment.core.domain.model.vo.Money;
-import radiata.service.payment.core.domain.model.vo.PaymentType;
 import radiata.service.payment.core.domain.repository.PaymentRepository;
 
 @DisplayName("PaymentSaver 테스트")

--- a/service/payment/payment-core/src/test/java/radiata/service/payment/core/service/TossPaymentServiceTest.java
+++ b/service/payment/payment-core/src/test/java/radiata/service/payment/core/service/TossPaymentServiceTest.java
@@ -18,7 +18,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 import radiata.common.domain.payment.dto.request.TossPaymentCreateRequestDto;
-import radiata.common.domain.payment.dto.response.TossPaymentCreateResponseDto;
+import radiata.common.domain.payment.dto.response.PaymentCreateResponseDto;
 import radiata.service.payment.core.domain.model.entity.Payment;
 import radiata.service.payment.core.implementation.PaymentRequester;
 import radiata.service.payment.core.implementation.PaymentSaver;
@@ -64,7 +64,7 @@ class TossPaymentServiceTest {
         }).when(paymentRequester).requestTossPayment(eq(payment), anyString());
 
         // when
-        TossPaymentCreateResponseDto responseDto = tossPaymentService.requestTossPayment(requestDto);
+        PaymentCreateResponseDto responseDto = tossPaymentService.requestTossPayment(requestDto);
 
         // then
         assertThat(responseDto).isNotNull();
@@ -100,7 +100,7 @@ class TossPaymentServiceTest {
         }).when(paymentRequester).requestTossPayment(eq(payment), anyString());
 
         // when
-        TossPaymentCreateResponseDto responseDto = tossPaymentService.requestTossPayment(requestDto);
+        PaymentCreateResponseDto responseDto = tossPaymentService.requestTossPayment(requestDto);
 
         // then
         assertThat(responseDto).isNotNull();


### PR DESCRIPTION
## #️⃣연관된 이슈

> - close #86 

## 📝작업 내용

> 간편결제 요청 API 구현 

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 파일 변경이 27개라고 겁먹지 마세요 ㅠㅠ -> `결제 도메인의 Enum`을 `common`으로 옮겨서, 관련 import들 변경되어서 많아보입니다.
> 주문 맡은 현도님,, 제가 결제 응답 DTO 명을 `TossPaymentCreateResponseDto`에서 `PaymentCreateResponseDto` 로 변경했습니다.. 테스트 결과 이상 없지만 알아두시긴 해야할 것 같아서 적어둡니다. 
> 리뷰는 `PaymentController`, `EasyPayPaymentService`, `PaymentSaver`, `PaymentRequester` 만 보셔도 될 것 같습니다~