### PR TITLE
[#80] Feat/order 주문 결제 승인 요청 - Feign 연동 추가 & 서비스 코드 분할 작업 & Kafka 설정 추가

### DIFF
--- a/common/src/main/java/radiata/common/domain/order/dto/request/AddPointRequestDto.java
+++ b/common/src/main/java/radiata/common/domain/order/dto/request/AddPointRequestDto.java
@@ -1,0 +1,15 @@
+package radiata.common.domain.order.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+
+public record AddPointRequestDto(
+    @NotBlank(message = "userId는 필수 입니다.")
+    String userId,
+
+    @NotBlank(message = "포인트 금액은 필수 입니다.")
+    @Min(value = 1, message = "포인트 금액은 1원 이상이어야 합니다.")
+    Integer point
+) {
+
+}

--- a/common/src/main/java/radiata/common/domain/order/dto/request/AddStockRequestDto.java
+++ b/common/src/main/java/radiata/common/domain/order/dto/request/AddStockRequestDto.java
@@ -1,0 +1,16 @@
+package radiata.common.domain.order.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+
+public record AddStockRequestDto(
+
+    @NotBlank(message = "ID는 필수 입니다.")
+    String id,
+
+    @NotBlank(message = "수량은 필수 입니다.")
+    @Min(value = 1, message = "수량은 1개 이상이어야 합니다.")
+    Integer quantity
+) {
+
+}

--- a/common/src/main/java/radiata/common/domain/order/dto/request/OrderCreateRequestDto.java
+++ b/common/src/main/java/radiata/common/domain/order/dto/request/OrderCreateRequestDto.java
@@ -1,11 +1,15 @@
 package radiata.common.domain.order.dto.request;
 
+import jakarta.validation.constraints.PositiveOrZero;
 import java.util.List;
 
 public record OrderCreateRequestDto(
     String address,
     String comment,
+
+    @PositiveOrZero(message = "적립금은 0원 이상이어야 합니다.")
     Integer point,
+
     List<OrderItemCreateRequestDto> itemList) {
 
 }

--- a/common/src/main/java/radiata/common/domain/order/dto/request/OrderEasyPaymentRequestDto.java
+++ b/common/src/main/java/radiata/common/domain/order/dto/request/OrderEasyPaymentRequestDto.java
@@ -1,0 +1,15 @@
+package radiata.common.domain.order.dto.request;
+
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.PositiveOrZero;
+
+public record OrderEasyPaymentRequestDto(
+
+    @PositiveOrZero(message = "amount는 0 이상이어야 합니다.")
+    Integer amount,
+
+    @Pattern(regexp = "^[0-9]{6}$", message = "password는 6자리 숫자여야 합니다.")
+    String password
+) {
+
+}

--- a/common/src/main/java/radiata/common/domain/order/dto/request/OrderItemCreateRequestDto.java
+++ b/common/src/main/java/radiata/common/domain/order/dto/request/OrderItemCreateRequestDto.java
@@ -1,10 +1,21 @@
 package radiata.common.domain.order.dto.request;
 
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
 public record OrderItemCreateRequestDto(
     String productId,
+
     String timeSaleProductId,
+
     String couponIssuedId,
+
+    @NotNull(message = "수량은 필수입니다.")
+    @Min(value = 1, message = "수량은 최소 1개 이상이어야 합니다.")
     Integer quantity,
+
+    @NotNull(message = "단가는 필수입니다.")
+    @Min(value = 1, message = "단가는 최소 1원 이상이어야 합니다.")
     Integer unitPrice) {
 
 }

--- a/common/src/main/java/radiata/common/domain/order/dto/request/OrderPaymentRequestDto.java
+++ b/common/src/main/java/radiata/common/domain/order/dto/request/OrderPaymentRequestDto.java
@@ -1,5 +1,0 @@
-package radiata.common.domain.order.dto.request;
-
-public record OrderPaymentRequestDto(String paymentKeyId, Integer amount) {
-
-}

--- a/common/src/main/java/radiata/common/domain/order/dto/request/OrderTossPaymentRequestDto.java
+++ b/common/src/main/java/radiata/common/domain/order/dto/request/OrderTossPaymentRequestDto.java
@@ -7,7 +7,7 @@ import jakarta.validation.constraints.PositiveOrZero;
 public record OrderTossPaymentRequestDto(
 
     @NotBlank(message = "paymentKey는 필수입니다.")
-    String paymentKeyId,
+    String paymentKey,
 
     @NotNull(message = "amount는 필수입니다.")
     @PositiveOrZero(message = "amount는 0 이상이어야 합니다.")

--- a/common/src/main/java/radiata/common/domain/order/dto/request/OrderTossPaymentRequestDto.java
+++ b/common/src/main/java/radiata/common/domain/order/dto/request/OrderTossPaymentRequestDto.java
@@ -1,0 +1,17 @@
+package radiata.common.domain.order.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+
+public record OrderTossPaymentRequestDto(
+
+    @NotBlank(message = "paymentKey는 필수입니다.")
+    String paymentKeyId,
+
+    @NotNull(message = "amount는 필수입니다.")
+    @PositiveOrZero(message = "amount는 0 이상이어야 합니다.")
+    Integer amount
+) {
+
+}

--- a/common/src/main/java/radiata/common/domain/order/dto/response/CouponInfoDto.java
+++ b/common/src/main/java/radiata/common/domain/order/dto/response/CouponInfoDto.java
@@ -1,0 +1,16 @@
+package radiata.common.domain.order.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record CouponInfoDto(String saleType, Integer discountValue) {
+
+    public static CouponInfoDto of(String saleType, Integer discountValue) {
+
+        return CouponInfoDto.builder()
+            .saleType(saleType)
+            .discountValue(discountValue)
+            .build();
+    }
+}

--- a/common/src/main/java/radiata/common/domain/order/dto/response/StockInfoDto.java
+++ b/common/src/main/java/radiata/common/domain/order/dto/response/StockInfoDto.java
@@ -1,0 +1,8 @@
+package radiata.common.domain.order.dto.response;
+
+public record StockInfoDto(
+    String id,
+    Integer quantity
+) {
+
+}

--- a/common/src/main/java/radiata/common/message/ExceptionMessage.java
+++ b/common/src/main/java/radiata/common/message/ExceptionMessage.java
@@ -55,9 +55,10 @@ public enum ExceptionMessage {
     NOT_EQUALS_PRICE(CONFLICT, "5002", "결제 요청 금액과 주문 금액이 일치하지 않습니다."),
     // 주문 취소가 가능하지 않은 주문 상태일 때.
     IMPOSSIBLE_CANCEL_ORDER_PAYMENT(CONFLICT, "5003", "주문 취소가 불가한 주문 상태입니다."),
-    // 상품 재고가 부족할 때
+    // 주문 실패 했을 때
     ORDER_CREATION_FAILED(BAD_REQUEST, "5004", "주문 생성에 실패했습니다."),
-
+    // 결제 실패했을 때
+    ORDER_PAYMENT_FAILED(BAD_REQUEST, "5005", "주문 상품 결제에 실패했습니다."),
 
     /* 쿠폰 6000번대 */
 

--- a/service/order/order-api/src/main/java/radiata/service/order/api/presentation/OrderController.java
+++ b/service/order/order-api/src/main/java/radiata/service/order/api/presentation/OrderController.java
@@ -7,6 +7,7 @@ import static radiata.common.message.SuccessMessage.GET_ORDER;
 import static radiata.common.message.SuccessMessage.UPDATE_ORDER;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -38,7 +39,7 @@ public class OrderController {
 
     // 주문 등록 - POST
     @PostMapping
-    public SuccessResponse<OrderResponseDto> createOrder(@RequestBody OrderCreateRequestDto requestDto,
+    public SuccessResponse<OrderResponseDto> createOrder(@Validated @RequestBody OrderCreateRequestDto requestDto,
         @RequestHeader("X-UserId") String userId) {
 
         return SuccessResponse.success(CREATE_ORDER.getMessage(), orderCreateService.createOrder(requestDto, userId));

--- a/service/order/order-api/src/main/java/radiata/service/order/api/presentation/OrderController.java
+++ b/service/order/order-api/src/main/java/radiata/service/order/api/presentation/OrderController.java
@@ -19,14 +19,20 @@ import radiata.common.domain.order.dto.request.OrderCreateRequestDto;
 import radiata.common.domain.order.dto.request.OrderPaymentRequestDto;
 import radiata.common.domain.order.dto.response.OrderResponseDto;
 import radiata.common.response.SuccessResponse;
-import radiata.service.order.core.service.OrderService;
+import radiata.service.order.core.service.OrderCreateService;
+import radiata.service.order.core.service.OrderReadService;
+import radiata.service.order.core.service.OrderRequestService;
+import radiata.service.order.core.service.OrderUpdateService;
 
 @RestController
 @RequestMapping("/orders")
 @RequiredArgsConstructor
 public class OrderController {
 
-    private final OrderService orderService;
+    private final OrderCreateService orderCreateService;
+    private final OrderRequestService orderRequestService;
+    private final OrderReadService orderReadService;
+    private final OrderUpdateService orderUpdateService;
 
 
     // 주문 등록 - POST
@@ -34,7 +40,7 @@ public class OrderController {
     public SuccessResponse<OrderResponseDto> createOrder(@RequestBody OrderCreateRequestDto requestDto,
         @RequestHeader("X-UserId") String userId) {
 
-        return SuccessResponse.success(CREATE_ORDER.getMessage(), orderService.createOrder(requestDto, userId));
+        return SuccessResponse.success(CREATE_ORDER.getMessage(), orderCreateService.createOrder(requestDto, userId));
     }
 
     // 주문 상세 조회 - GET
@@ -42,7 +48,7 @@ public class OrderController {
     public SuccessResponse<OrderResponseDto> getOrder(@PathVariable("orderId") String orderId,
         @RequestHeader("X-UserId") String userId) {
 
-        return SuccessResponse.success(GET_ORDER.getMessage(), orderService.getOrder(orderId, userId));
+        return SuccessResponse.success(GET_ORDER.getMessage(), orderReadService.getOrder(orderId, userId));
     }
 
     // 주문 목록 조회 - GET
@@ -51,7 +57,7 @@ public class OrderController {
     public SuccessResponse<OrderResponseDto> cancelOrder(@PathVariable("orderId") String orderId,
         @RequestHeader("X-UserId") String userId) {
 
-        return SuccessResponse.success(CANCEL_ORDER.getMessage(), orderService.cancelOrder(orderId, userId));
+        return SuccessResponse.success(CANCEL_ORDER.getMessage(), orderRequestService.cancelOrder(orderId, userId));
     }
 
     // 주문 환불 요청 - POST("/{orderId}/refunded")
@@ -62,7 +68,7 @@ public class OrderController {
         @RequestBody OrderPaymentRequestDto requestDto) {
 
         return SuccessResponse.success(COMPLETE_ORDER_PAYMENT.getMessage(),
-            orderService.sendPaymentRequest(orderId, userId, requestDto));
+            orderRequestService.sendPaymentRequest(orderId, userId, requestDto));
     }
 
     // 주문 상태 변경(배송 대기 중) - PATCH
@@ -70,7 +76,7 @@ public class OrderController {
     public SuccessResponse<OrderResponseDto> pendShipping(@PathVariable("orderId") String orderId) {
 
         return SuccessResponse.success(UPDATE_ORDER.getMessage(),
-            orderService.updateStatusPendingShipping(orderId));
+            orderUpdateService.updateStatusPendingShipping(orderId));
     }
 
     // 주문 상태 변경(배송 중) - PATCH
@@ -78,7 +84,7 @@ public class OrderController {
     public SuccessResponse<OrderResponseDto> shippingInProgress(@PathVariable("orderId") String orderId) {
 
         return SuccessResponse.success(UPDATE_ORDER.getMessage(),
-            orderService.updateStatusShipping(orderId));
+            orderUpdateService.updateStatusShipping(orderId));
     }
 
     // 주문 상태 변경(배송 완료) - PATCH
@@ -86,7 +92,7 @@ public class OrderController {
     public SuccessResponse<OrderResponseDto> completeShipping(@PathVariable("orderId") String orderId) {
 
         return SuccessResponse.success(UPDATE_ORDER.getMessage(),
-            orderService.updateStatusCompletedShipping(orderId));
+            orderUpdateService.updateStatusCompletedShipping(orderId));
     }
     // 주문 내역 삭제
 

--- a/service/order/order-api/src/main/java/radiata/service/order/api/presentation/OrderController.java
+++ b/service/order/order-api/src/main/java/radiata/service/order/api/presentation/OrderController.java
@@ -16,7 +16,8 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import radiata.common.domain.order.dto.request.OrderCreateRequestDto;
-import radiata.common.domain.order.dto.request.OrderPaymentRequestDto;
+import radiata.common.domain.order.dto.request.OrderEasyPaymentRequestDto;
+import radiata.common.domain.order.dto.request.OrderTossPaymentRequestDto;
 import radiata.common.domain.order.dto.response.OrderResponseDto;
 import radiata.common.response.SuccessResponse;
 import radiata.service.order.core.service.OrderCreateService;
@@ -61,14 +62,26 @@ public class OrderController {
     }
 
     // 주문 환불 요청 - POST("/{orderId}/refunded")
-    // 주문 결제 승인 요청 및 완료
-    @PostMapping("/{orderId}/payment-requested")
-    public SuccessResponse<OrderResponseDto> completePayment(@PathVariable("orderId") String orderId,
+
+    // 주문 결제 승인 요청 및 완료 - 간편결제
+    @PostMapping("/{orderId}/payment-requested/easypay")
+    public SuccessResponse<OrderResponseDto> requestCompleteEasyPayment(@PathVariable("orderId") String orderId,
         @RequestHeader("X-UserId") String userId,
-        @RequestBody OrderPaymentRequestDto requestDto) {
+        @RequestBody OrderEasyPaymentRequestDto requestDto) {
 
         return SuccessResponse.success(COMPLETE_ORDER_PAYMENT.getMessage(),
-            orderRequestService.sendPaymentRequest(orderId, userId, requestDto));
+            orderRequestService.sendEasyPaymentRequest(orderId, userId, requestDto));
+    }
+
+
+    // 주문 결제 승인 요청 및 완료 - 토스
+    @PostMapping("/{orderId}/payment-requested/toss")
+    public SuccessResponse<OrderResponseDto> requestCompleteTossPayment(@PathVariable("orderId") String orderId,
+        @RequestHeader("X-UserId") String userId,
+        @RequestBody OrderTossPaymentRequestDto requestDto) {
+
+        return SuccessResponse.success(COMPLETE_ORDER_PAYMENT.getMessage(),
+            orderRequestService.sendTossPaymentRequest(orderId, userId, requestDto));
     }
 
     // 주문 상태 변경(배송 대기 중) - PATCH

--- a/service/order/order-api/src/main/java/radiata/service/order/api/presentation/OrderController.java
+++ b/service/order/order-api/src/main/java/radiata/service/order/api/presentation/OrderController.java
@@ -6,8 +6,8 @@ import static radiata.common.message.SuccessMessage.CREATE_ORDER;
 import static radiata.common.message.SuccessMessage.GET_ORDER;
 import static radiata.common.message.SuccessMessage.UPDATE_ORDER;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -39,7 +39,7 @@ public class OrderController {
 
     // 주문 등록 - POST
     @PostMapping
-    public SuccessResponse<OrderResponseDto> createOrder(@Validated @RequestBody OrderCreateRequestDto requestDto,
+    public SuccessResponse<OrderResponseDto> createOrder(@Valid @RequestBody OrderCreateRequestDto requestDto,
         @RequestHeader("X-UserId") String userId) {
 
         return SuccessResponse.success(CREATE_ORDER.getMessage(), orderCreateService.createOrder(requestDto, userId));

--- a/service/order/order-api/src/main/resources/application.yml
+++ b/service/order/order-api/src/main/resources/application.yml
@@ -3,8 +3,6 @@ spring:
     name: order-service
   config:
     import: classpath:application-database.yml
-  profiles:
-    default: dev
   cloud:
     openfeign:
       okhttp:

--- a/service/order/order-core/src/main/java/radiata/service/order/core/config/KafkaConfig.java
+++ b/service/order/order-core/src/main/java/radiata/service/order/core/config/KafkaConfig.java
@@ -1,9 +1,32 @@
 package radiata.service.order.core.config;
 
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
 
 @Configuration
 // TODO - 정해지면 종류 별(결제, 타임세일 상품, 발급 쿠폰, 상품, 적립금(유저))로 등록
 public class KafkaConfig {
 
+    @Bean
+    public ProducerFactory<String, String> paymentRollbackProducerFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+        // TODO - 포트 주소 "yunjae.click"으로 수정 예정
+        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        return new DefaultKafkaProducerFactory<>(configProps);
+    }
+
+    @Bean
+    public KafkaTemplate<String, String> paymentRollbackKafkaTemplate() {
+        return new KafkaTemplate<>(paymentRollbackProducerFactory());
+    }
 }

--- a/service/order/order-core/src/main/java/radiata/service/order/core/config/KafkaConfig.java
+++ b/service/order/order-core/src/main/java/radiata/service/order/core/config/KafkaConfig.java
@@ -10,13 +10,16 @@ import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.kafka.support.serializer.JsonSerializer;
+import radiata.common.domain.order.dto.request.AddPointRequestDto;
+import radiata.common.domain.order.dto.request.AddStockRequestDto;
 
 @Configuration
 // TODO - 정해지면 종류 별(결제, 타임세일 상품, 발급 쿠폰, 상품, 적립금(유저))로 등록
 public class KafkaConfig {
 
+    // 쿠폰 상태 변경 & 결제 취소 요청
     @Bean
-    public ProducerFactory<String, String> paymentRollbackProducerFactory() {
+    public ProducerFactory<String, String> cancelRequestProducerFactory() {
         Map<String, Object> configProps = new HashMap<>();
         // TODO - 포트 주소 "yunjae.click"으로 수정 예정
         configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
@@ -26,7 +29,37 @@ public class KafkaConfig {
     }
 
     @Bean
-    public KafkaTemplate<String, String> paymentRollbackKafkaTemplate() {
-        return new KafkaTemplate<>(paymentRollbackProducerFactory());
+    public KafkaTemplate<String, String> cancelRequestKafkaTemplate() {
+        return new KafkaTemplate<>(cancelRequestProducerFactory());
+    }
+
+    // 타임세일 상품 & 상품 재고 증감 요청
+    @Bean
+    public ProducerFactory<String, AddStockRequestDto> addStockProducerFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        return new DefaultKafkaProducerFactory<>(configProps);
+    }
+
+    @Bean
+    public KafkaTemplate<String, AddStockRequestDto> addStockKafkaTemplate() {
+        return new KafkaTemplate<>(addStockProducerFactory());
+    }
+
+    // 적립금 증감 요청
+    @Bean
+    public ProducerFactory<String, AddPointRequestDto> addPointProducerFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        return new DefaultKafkaProducerFactory<>(configProps);
+    }
+
+    @Bean
+    public KafkaTemplate<String, AddPointRequestDto> addPointKafkaTemplate() {
+        return new KafkaTemplate<>(addPointProducerFactory());
     }
 }

--- a/service/order/order-core/src/main/java/radiata/service/order/core/domain/model/entity/Order.java
+++ b/service/order/order-core/src/main/java/radiata/service/order/core/domain/model/entity/Order.java
@@ -50,6 +50,7 @@ public class Order extends BaseEntity {
 
     private String paymentId;
 
+    @Enumerated(EnumType.STRING)
     private PaymentType paymentType;
     // TODO - 사용 예정
     private Integer usedPoint;

--- a/service/order/order-core/src/main/java/radiata/service/order/core/service/OrderCreateService.java
+++ b/service/order/order-core/src/main/java/radiata/service/order/core/service/OrderCreateService.java
@@ -1,0 +1,34 @@
+package radiata.service.order.core.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import radiata.common.domain.order.dto.request.OrderCreateRequestDto;
+import radiata.common.domain.order.dto.response.OrderResponseDto;
+import radiata.service.order.core.domain.model.entity.Order;
+import radiata.service.order.core.implemetation.OrderIdCreator;
+import radiata.service.order.core.implemetation.OrderSaver;
+import radiata.service.order.core.service.mapper.OrderMapper;
+
+@Service
+@RequiredArgsConstructor
+public class OrderCreateService {
+
+    private final OrderIdCreator orderIdCreator;
+    private final OrderSaver orderSaver;
+    private final OrderMapper orderMapper;
+    private final OrderItemService orderItemService;
+
+    // 주문 생성
+    @Transactional
+    public OrderResponseDto createOrder(OrderCreateRequestDto requestDto, String userId) {
+        // 주문 ID 생성
+        String orderId = orderIdCreator.create();
+        // 초기 주문 생성
+        Order order = orderSaver.save(orderMapper.toEntity(requestDto, orderId, userId));
+        // 주문 상품 목록 처리
+        orderItemService.processOrderItems(requestDto, order, userId);
+        // 주문 상품 목록 추가 & 반환
+        return orderMapper.toDto(order).withItemList(orderItemService.toDtoSet(order.getOrderItems()));
+    }
+}

--- a/service/order/order-core/src/main/java/radiata/service/order/core/service/OrderItemService.java
+++ b/service/order/order-core/src/main/java/radiata/service/order/core/service/OrderItemService.java
@@ -46,7 +46,7 @@ public class OrderItemService {
             int quantity = itemCreateDto.quantity();
             // 1️⃣ 타임세일 상품 재고 확인 및 차감
             String timeSaleProductId = itemCreateDto.timeSaleProductId();
-            processService.checkAndDeductTimeSaleProduct(rollbackContext, timeSaleProductId);
+            processService.checkAndDeductTimeSaleProduct(rollbackContext, timeSaleProductId, quantity);
             // 2️⃣ 상품 재고 확인 및 차감
             String productId = itemCreateDto.productId();
             processService.checkAndDeductStock(rollbackContext, productId, quantity);

--- a/service/order/order-core/src/main/java/radiata/service/order/core/service/OrderItemService.java
+++ b/service/order/order-core/src/main/java/radiata/service/order/core/service/OrderItemService.java
@@ -1,9 +1,6 @@
 package radiata.service.order.core.service;
 
-import feign.FeignException;
-import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -13,11 +10,10 @@ import radiata.common.domain.order.dto.request.OrderCreateRequestDto;
 import radiata.common.domain.order.dto.request.OrderItemCreateRequestDto;
 import radiata.common.domain.order.dto.response.CouponInfoDto;
 import radiata.common.domain.order.dto.response.OrderItemResponseDto;
-import radiata.common.exception.BusinessException;
-import radiata.common.message.ExceptionMessage;
 import radiata.service.order.core.domain.model.entity.Order;
 import radiata.service.order.core.domain.model.entity.OrderItem;
 import radiata.service.order.core.implemetation.OrderIdCreator;
+import radiata.service.order.core.service.context.OrderRollbackContext;
 import radiata.service.order.core.service.mapper.OrderItemMapper;
 
 @Implementation
@@ -28,7 +24,6 @@ public class OrderItemService {
     private final OrderItemMapper orderItemMapper;
     private final OrderIdCreator orderIdCreator;
     private final ProcessService processService;
-    private final RollbackService rollbackService;
 
     public Set<OrderItemResponseDto> toDtoSet(Set<OrderItem> orderItems) {
 
@@ -39,49 +34,32 @@ public class OrderItemService {
 
     // 주문 상품 처리 로직
     public void processOrderItems(OrderCreateRequestDto requestDto, Order order, String userId) {
-        // 보상 트랜잭션 관리 변수
-        List<String> deductedTimeSales = new ArrayList<>(); // 타임세일 재고 차감 목록
-        List<String> deductedProducts = new ArrayList<>();  // 재고 차감 목록
-        List<String> usedCoupons = new ArrayList<>();       // 사용된 쿠폰 목록
+        // 보상 트랜잭션 관리 객체
+        OrderRollbackContext rollbackContext = new OrderRollbackContext();
 
         Set<OrderItem> orderItems = new HashSet<>();        // 주문 상품 목록 - set
         int orderPrice = 0;                                 // 총 주문 금액 - set
 
         for (OrderItemCreateRequestDto itemCreateDto : requestDto.itemList()) {
-            try {
-                // 주문 상품 ID 생성 및 주문 상품 목록에 추가
-                OrderItem orderItem = createIdAndAddOrderItem(orderItems, itemCreateDto, order);
-                int quantity = itemCreateDto.quantity();
-                // 1️⃣ 타임세일 상품 재고 확인 및 차감
-                String timeSaleProductId = itemCreateDto.timeSaleProductId();
-                processService.checkAndDeductTimeSaleProduct(deductedTimeSales, timeSaleProductId);
-                // 2️⃣ 상품 재고 확인 및 차감
-                String productId = itemCreateDto.productId();
-                processService.checkAndDeductStock(deductedProducts, productId, quantity);
-                // 3️⃣ 쿠폰 사용 여부 체크
-                String couponIssuedId = itemCreateDto.couponIssuedId();
-                CouponInfoDto couponInfoDto = processService.checkAndUseCoupon(usedCoupons, couponIssuedId, userId);
-                // 상품 금액 설정 및 총 금액에 추가
-                orderPrice += orderItem.setPrice(couponInfoDto.saleType(), couponInfoDto.discountValue());
-
-            } catch (FeignException e) {
-                // 보상 트랜잭션
-                rollbackService.createOrderItemsRollbackTransaction(deductedTimeSales, deductedProducts, usedCoupons);
-                throw new BusinessException(ExceptionMessage.ORDER_CREATION_FAILED);
-            }
+            // 주문 상품 ID 생성 및 주문 상품 목록에 추가
+            OrderItem orderItem = createIdAndAddOrderItem(orderItems, itemCreateDto, order);
+            int quantity = itemCreateDto.quantity();
+            // 1️⃣ 타임세일 상품 재고 확인 및 차감
+            String timeSaleProductId = itemCreateDto.timeSaleProductId();
+            processService.checkAndDeductTimeSaleProduct(rollbackContext, timeSaleProductId);
+            // 2️⃣ 상품 재고 확인 및 차감
+            String productId = itemCreateDto.productId();
+            processService.checkAndDeductStock(rollbackContext, productId, quantity);
+            // 3️⃣ 쿠폰 사용 여부 체크
+            String couponIssuedId = itemCreateDto.couponIssuedId();
+            CouponInfoDto couponInfoDto = processService.checkAndUseCoupon(rollbackContext, couponIssuedId, userId);
+            // 상품 금액 설정 및 총 금액에 추가
+            orderPrice += orderItem.setPrice(couponInfoDto.saleType(), couponInfoDto.discountValue());
         }
 
-        // 적립금 사용 시
-        try {
-            // TODO - process에 구현해야 함
-            int point = requestDto.point();
-
-        } catch (FeignException e) {
-            // 보상 트랜잭션 - 비동기 처리 (Kafka 사용)
-            rollbackService.createOrderItemsRollbackTransaction(deductedTimeSales, deductedProducts, usedCoupons);
-            throw new BusinessException(ExceptionMessage.ORDER_CREATION_FAILED);
-        }
-
+        // 4️⃣ 적립금 확인 및 차감
+        int point = requestDto.point();
+        processService.checkAndUsePoint(rollbackContext, order, point, userId);
         // 주문 - 금액 & 상품 목록 지정
         order.setOrderPriceAndItems(orderPrice, orderItems);
     }
@@ -89,6 +67,7 @@ public class OrderItemService {
     // 주문 상품 ID 생성 및 주문 상품 목록에 추가
     private OrderItem createIdAndAddOrderItem(Set<OrderItem> orderItems, OrderItemCreateRequestDto itemCreateDto,
         Order order) {
+
         String orderItemId = orderIdCreator.create();
         OrderItem orderItem = orderItemMapper.toEntity(itemCreateDto, orderItemId, order);
         orderItems.add(orderItem);

--- a/service/order/order-core/src/main/java/radiata/service/order/core/service/OrderReadService.java
+++ b/service/order/order-core/src/main/java/radiata/service/order/core/service/OrderReadService.java
@@ -1,0 +1,31 @@
+package radiata.service.order.core.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import radiata.common.domain.order.dto.response.OrderResponseDto;
+import radiata.service.order.core.domain.model.entity.Order;
+import radiata.service.order.core.implemetation.OrderReader;
+import radiata.service.order.core.implemetation.OrderValidator;
+import radiata.service.order.core.service.mapper.OrderMapper;
+
+@Service
+@RequiredArgsConstructor
+public class OrderReadService {
+
+    private final OrderMapper orderMapper;
+    private final OrderReader orderReader;
+    private final OrderValidator orderValidator;
+    private final OrderItemService orderItemService;
+
+    // 주문 상세 조회
+    @Transactional(readOnly = true)
+    public OrderResponseDto getOrder(String orderId, String userId) {
+        // 주문 조회
+        Order order = orderReader.readOrder(orderId);
+        // 사용자의 주문 내역인지 확인
+        orderValidator.validateUserOwnsOrder(order.getUserId(), userId);
+        // 주문 상품 목록 추가 & 반환
+        return orderMapper.toDto(order).withItemList(orderItemService.toDtoSet(order.getOrderItems()));
+    }
+}

--- a/service/order/order-core/src/main/java/radiata/service/order/core/service/OrderRequestService.java
+++ b/service/order/order-core/src/main/java/radiata/service/order/core/service/OrderRequestService.java
@@ -3,7 +3,8 @@ package radiata.service.order.core.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import radiata.common.domain.order.dto.request.OrderPaymentRequestDto;
+import radiata.common.domain.order.dto.request.OrderEasyPaymentRequestDto;
+import radiata.common.domain.order.dto.request.OrderTossPaymentRequestDto;
 import radiata.common.domain.order.dto.response.OrderResponseDto;
 import radiata.service.order.core.domain.model.constant.OrderStatus;
 import radiata.service.order.core.domain.model.entity.Order;
@@ -20,11 +21,13 @@ public class OrderRequestService {
     private final OrderMapper orderMapper;
     private final OrderValidator orderValidator;
     private final OrderItemService orderItemService;
+    private final ProcessService processService;
 
 
-    // 결제 요청 -> 주문 상태 (결제 요청 중 -> 결제 대기 중 -> 결제 완료)
+    // 간편 결제 요청
     @Transactional
-    public OrderResponseDto sendPaymentRequest(String orderId, String userId, OrderPaymentRequestDto requestDto) {
+    public OrderResponseDto sendEasyPaymentRequest(String orderId, String userId,
+        OrderEasyPaymentRequestDto requestDto) {
         // 주문 조회
         Order order = orderReader.readOrder(orderId);
         // 유저의 주문인지 체크
@@ -33,15 +36,29 @@ public class OrderRequestService {
         orderValidator.checkCanMoveToNextStatus(order, OrderStatus.PAYMENT_PENDING);
         // 주문 금액 일치 확인
         orderValidator.IsEqualsOrderPrice(requestDto.amount(), order.getOrderPrice());
+        // 간편 결제 요청
+        processService.requestEasyPayment(requestDto, order, userId);
+        // 주문 상태 체크 & 변경(결제 완료)
+        orderValidator.checkCanMoveToNextStatus(order, OrderStatus.PAYMENT_COMPLETED);
+        // 반환
+        return orderMapper.toDto(order).withItemList(orderItemService.toDtoSet(order.getOrderItems()));
+    }
 
-        /* TODO - 결제 승인 요청 (openFeign) orderId, tossPaymentId, amount - Merge 후
-            1) 성공 - 다음
-            2) 실패 시 (FeignException - 결제 실패)
-            - 주문 취소 처리 - 보상 트랜잭션(롤백)
-         */
 
-        // paymentId 지정
-//        order.setPaymentIdAndType(paymentId, type);
+    // 토스 결제 요청
+    @Transactional
+    public OrderResponseDto sendTossPaymentRequest(String orderId, String userId,
+        OrderTossPaymentRequestDto requestDto) {
+        // 주문 조회
+        Order order = orderReader.readOrder(orderId);
+        // 유저의 주문인지 체크
+        orderValidator.validateUserOwnsOrder(order.getUserId(), userId);
+        // 주문 상태 체크 & 변경(결제 대기 중)
+        orderValidator.checkCanMoveToNextStatus(order, OrderStatus.PAYMENT_PENDING);
+        // 주문 금액 일치 확인
+        orderValidator.IsEqualsOrderPrice(requestDto.amount(), order.getOrderPrice());
+        // 토스 페이 결제요청
+        processService.requestTossPayment(requestDto, order, userId);
         // 주문 상태 체크 & 변경(결제 완료)
         orderValidator.checkCanMoveToNextStatus(order, OrderStatus.PAYMENT_COMPLETED);
         // 반환
@@ -60,7 +77,7 @@ public class OrderRequestService {
         orderValidator.checkStatusIsPaymentLevel(order.getStatus());
         // 주문 상태 업데이트 - 주문 취소 요청
         order.updateOrderStatus(OrderStatus.PAYMENT_CANCEL_REQUESTED);
-        // TODO - PaymentClient로 결제 취소 요청. & 롤백 (주문 상품 목록 재고 ++ & 쿠폰 이슈 복구 & 주문 상태 이전으로? - 스케줄러)
+        // TODO - 결제 취소, 타임세일 상품, 상품 재고, 쿠폰 -> 롤백 (주문 상품 목록 재고 ++ & 쿠폰 이슈 복구 & 주문 상태 이전으로? - 스케줄러)
         for (OrderItem orderItem : order.getOrderItems()) {
             /*
             try - 1) 재고 증감

--- a/service/order/order-core/src/main/java/radiata/service/order/core/service/OrderRequestService.java
+++ b/service/order/order-core/src/main/java/radiata/service/order/core/service/OrderRequestService.java
@@ -8,7 +8,6 @@ import radiata.common.domain.order.dto.request.OrderTossPaymentRequestDto;
 import radiata.common.domain.order.dto.response.OrderResponseDto;
 import radiata.service.order.core.domain.model.constant.OrderStatus;
 import radiata.service.order.core.domain.model.entity.Order;
-import radiata.service.order.core.domain.model.entity.OrderItem;
 import radiata.service.order.core.implemetation.OrderReader;
 import radiata.service.order.core.implemetation.OrderValidator;
 import radiata.service.order.core.service.mapper.OrderMapper;
@@ -73,20 +72,10 @@ public class OrderRequestService {
         Order order = orderReader.readOrder(orderId);
         // 사용자의 주문 내역인지 확인
         orderValidator.validateUserOwnsOrder(order.getUserId(), userId);
-        // 주문 상태 체크 - 결제 단계만 주문 취소 가능
+        // 결제 단계 상태만 취소 가능
         orderValidator.checkStatusIsPaymentLevel(order.getStatus());
-        // 주문 상태 업데이트 - 주문 취소 요청
-        order.updateOrderStatus(OrderStatus.PAYMENT_CANCEL_REQUESTED);
-        // TODO - 결제 취소, 타임세일 상품, 상품 재고, 쿠폰 -> 롤백 (주문 상품 목록 재고 ++ & 쿠폰 이슈 복구 & 주문 상태 이전으로? - 스케줄러)
-        for (OrderItem orderItem : order.getOrderItems()) {
-            /*
-            try - 1) 재고 증감
-             */
-
-            /*
-            try - 2) 쿠폰 상태 변경 - USED -> ISSUED
-            */
-        }
+        // 주문 취소 - 롤백 처리
+        processService.processCancelOrder(order);
         // 주문 상태 체크
         orderValidator.checkStatusIsPaymentCancelRequested(order.getStatus());
         // 주문 상태 업데이트 - 주문 취소 완료

--- a/service/order/order-core/src/main/java/radiata/service/order/core/service/OrderUpdateService.java
+++ b/service/order/order-core/src/main/java/radiata/service/order/core/service/OrderUpdateService.java
@@ -1,0 +1,54 @@
+package radiata.service.order.core.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import radiata.common.domain.order.dto.response.OrderResponseDto;
+import radiata.service.order.core.domain.model.constant.OrderStatus;
+import radiata.service.order.core.domain.model.entity.Order;
+import radiata.service.order.core.implemetation.OrderReader;
+import radiata.service.order.core.implemetation.OrderValidator;
+import radiata.service.order.core.service.mapper.OrderMapper;
+
+@Service
+@RequiredArgsConstructor
+public class OrderUpdateService {
+
+    private final OrderMapper orderMapper;
+    private final OrderItemService orderItemService;
+    private final OrderReader orderReader;
+    private final OrderValidator orderValidator;
+
+    // 주문 상태 변경 (배송 대기 중)
+    @Transactional
+    public OrderResponseDto updateStatusPendingShipping(String orderId) {
+        // 주문 조회
+        Order order = orderReader.readOrder(orderId);
+        // 주문 상태 체크 & 변경(배송 대기 중)
+        orderValidator.checkCanMoveToNextStatus(order, OrderStatus.SHIPPING_PENDING);
+        // 반환
+        return orderMapper.toDto(order).withItemList(orderItemService.toDtoSet(order.getOrderItems()));
+    }
+
+    // 주문 상태 변경 (배송 중)
+    @Transactional
+    public OrderResponseDto updateStatusShipping(String orderId) {
+        // 주문 조회
+        Order order = orderReader.readOrder(orderId);
+        // 주문 상태 체크 & 변경(배송 중)
+        orderValidator.checkCanMoveToNextStatus(order, OrderStatus.SHIPPING_IN_PROGRESS);
+        // 반환
+        return orderMapper.toDto(order).withItemList(orderItemService.toDtoSet(order.getOrderItems()));
+    }
+
+    // 주문 상태 변경 (배송 완료)
+    @Transactional
+    public OrderResponseDto updateStatusCompletedShipping(String orderId) {
+        // 주문 조회
+        Order order = orderReader.readOrder(orderId);
+        // 주문 상태 체크 & 변경(배송 완료)
+        orderValidator.checkCanMoveToNextStatus(order, OrderStatus.SHIPPING_COMPLETED);
+        // 반환
+        return orderMapper.toDto(order).withItemList(orderItemService.toDtoSet(order.getOrderItems()));
+    }
+}

--- a/service/order/order-core/src/main/java/radiata/service/order/core/service/ProcessService.java
+++ b/service/order/order-core/src/main/java/radiata/service/order/core/service/ProcessService.java
@@ -38,11 +38,11 @@ public class ProcessService {
 
 
     // 타임세일상품 재고 확인 및 차감 요청
-    public void checkAndDeductTimeSaleProduct(OrderRollbackContext context, String timeSaleProductId) {
+    public void checkAndDeductTimeSaleProduct(OrderRollbackContext context, String timeSaleProductId, int quantity) {
         try {
             if (timeSaleProductId != null) {
                 timeSaleProductClient.checkAndDeductTimeSaleProduct(timeSaleProductId);
-                context.addDeductedTimeSale(timeSaleProductId);
+                context.addDeductedTimeSale(timeSaleProductId, quantity);
             }
         } catch (FeignException e) {
             log.error("[TimeSale-Service FeignException]: Deduct TimeSale Product Request Error");
@@ -55,7 +55,7 @@ public class ProcessService {
     public void checkAndDeductStock(OrderRollbackContext context, String productId, int quantity) {
         try {
             productClient.checkAndDeductStock(new ProductDeductRequestDto(productId, quantity));
-            context.addDeductedProduct(productId);
+            context.addDeductedProduct(productId, quantity);
         } catch (FeignException e) {
             log.error("[Brand(Product)-Service FeignException]: DeductStock Request Error");
             rollbackService.createOrderItemsRollbackTransaction(context);

--- a/service/order/order-core/src/main/java/radiata/service/order/core/service/ProcessService.java
+++ b/service/order/order-core/src/main/java/radiata/service/order/core/service/ProcessService.java
@@ -108,7 +108,7 @@ public class ProcessService {
         try {
             EasyPayCreateRequestDto paymentRequestDto = createEasyPayRequestDto(userId, requestDto);
             String paymentId = paymentClient.requestEasyPay(paymentRequestDto).data().paymentId();
-            order.setPaymentIdAndType(paymentId, PaymentType.TOSS_PAYMENTS);
+            order.setPaymentIdAndType(paymentId, PaymentType.EASY_PAY);
         } catch (FeignException e) {
             log.error("[Payment-Service FeignException]: EasyPay Request Error");
             rollbackService.cancelOrderItemsRollback(order);

--- a/service/order/order-core/src/main/java/radiata/service/order/core/service/ProcessService.java
+++ b/service/order/order-core/src/main/java/radiata/service/order/core/service/ProcessService.java
@@ -1,22 +1,36 @@
 package radiata.service.order.core.service;
 
+import feign.FeignException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import radiata.common.domain.brand.request.ProductDeductRequestDto;
 import radiata.common.domain.coupon.dto.response.CouponResponseDto;
+import radiata.common.domain.order.dto.request.OrderEasyPaymentRequestDto;
+import radiata.common.domain.order.dto.request.OrderTossPaymentRequestDto;
 import radiata.common.domain.order.dto.response.CouponInfoDto;
+import radiata.common.domain.payment.constant.PaymentType;
+import radiata.common.domain.payment.dto.request.EasyPayCreateRequestDto;
+import radiata.common.domain.payment.dto.request.TossPaymentCreateRequestDto;
+import radiata.common.exception.BusinessException;
+import radiata.common.message.ExceptionMessage;
+import radiata.service.order.core.domain.model.entity.Order;
 import radiata.service.order.core.service.client.CouponIssueClient;
+import radiata.service.order.core.service.client.PaymentClient;
 import radiata.service.order.core.service.client.ProductClient;
 import radiata.service.order.core.service.client.TimeSaleProductClient;
 
 @Service
+@Slf4j(topic = "Process-Service")
 @RequiredArgsConstructor
 public class ProcessService {
 
     private final TimeSaleProductClient timeSaleProductClient;
     private final ProductClient productClient;
     private final CouponIssueClient couponIssueClient;
+    private final PaymentClient paymentClient;
+    private final RollbackService rollbackService;
 
 
     // 타임세일상품 재고 확인 및 차감 요청
@@ -48,6 +62,32 @@ public class ProcessService {
         return CouponInfoDto.of(saleType, discountValue);
     }
 
+    // 결제 승인 요청 - 간편결제
+    public void requestEasyPayment(OrderEasyPaymentRequestDto requestDto, Order order, String userId) {
+        try {
+            EasyPayCreateRequestDto paymentRequestDto = createEasyPayRequestDto(userId, requestDto);
+            String paymentId = paymentClient.requestEasyPay(paymentRequestDto).data().paymentId();
+            order.setPaymentIdAndType(paymentId, PaymentType.TOSS_PAYMENTS);
+        } catch (FeignException e) {
+            // TODO -> 주문 취소 처리 - 보상 트랜잭션(롤백)
+            rollbackService.cancelOrderItemsRollback(order.getOrderItems());
+            throw new BusinessException(ExceptionMessage.ORDER_PAYMENT_FAILED);
+        }
+    }
+
+    // 결제 승인 요청 - 토스페이
+    public void requestTossPayment(OrderTossPaymentRequestDto requestDto, Order order, String userId) {
+        try {
+            TossPaymentCreateRequestDto paymentRequestDto = createTossRequestDto(order.getId(), userId, requestDto);
+            String paymentId = paymentClient.requestTossPayment(paymentRequestDto).data().paymentId();
+            order.setPaymentIdAndType(paymentId, PaymentType.TOSS_PAYMENTS);
+        } catch (FeignException e) {
+            // TODO -> 주문 취소 처리 - 보상 트랜잭션(롤백)
+            rollbackService.cancelOrderItemsRollback(order.getOrderItems());
+            throw new BusinessException(ExceptionMessage.ORDER_PAYMENT_FAILED);
+        }
+    }
+
     private int checkCouponSaleType(CouponResponseDto couponInfo) {
         // TODO - CouponType enum 으로 수정
         if (couponInfo.couponSaleType().equals("AMOUNT")) {
@@ -55,4 +95,27 @@ public class ProcessService {
         }
         return couponInfo.discountRate();
     }
+
+
+    // TODO - 결제요청 createDto 전략 패턴 적용하기
+    private EasyPayCreateRequestDto createEasyPayRequestDto(String userId,
+        OrderEasyPaymentRequestDto requestDto) {
+
+        return new EasyPayCreateRequestDto(
+            userId,
+            requestDto.amount().longValue(),
+            requestDto.password());
+    }
+
+    private TossPaymentCreateRequestDto createTossRequestDto(String orderId, String userId,
+        OrderTossPaymentRequestDto requestDto) {
+
+        return new TossPaymentCreateRequestDto(
+            orderId,
+            userId,
+            requestDto.paymentKeyId(),
+            requestDto.amount().longValue());
+    }
+
+
 }

--- a/service/order/order-core/src/main/java/radiata/service/order/core/service/ProcessService.java
+++ b/service/order/order-core/src/main/java/radiata/service/order/core/service/ProcessService.java
@@ -1,9 +1,9 @@
 package radiata.service.order.core.service;
 
 import feign.FeignException;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import radiata.common.domain.brand.request.ProductDeductRequestDto;
 import radiata.common.domain.coupon.dto.response.CouponResponseDto;
@@ -13,6 +13,7 @@ import radiata.common.domain.order.dto.response.CouponInfoDto;
 import radiata.common.domain.payment.constant.PaymentType;
 import radiata.common.domain.payment.dto.request.EasyPayCreateRequestDto;
 import radiata.common.domain.payment.dto.request.TossPaymentCreateRequestDto;
+import radiata.common.domain.user.dto.request.PointModifyRequestDto;
 import radiata.common.exception.BusinessException;
 import radiata.common.message.ExceptionMessage;
 import radiata.service.order.core.domain.model.entity.Order;
@@ -20,6 +21,8 @@ import radiata.service.order.core.service.client.CouponIssueClient;
 import radiata.service.order.core.service.client.PaymentClient;
 import radiata.service.order.core.service.client.ProductClient;
 import radiata.service.order.core.service.client.TimeSaleProductClient;
+import radiata.service.order.core.service.client.UserClient;
+import radiata.service.order.core.service.context.OrderRollbackContext;
 
 @Service
 @Slf4j(topic = "Process-Service")
@@ -30,36 +33,71 @@ public class ProcessService {
     private final ProductClient productClient;
     private final CouponIssueClient couponIssueClient;
     private final PaymentClient paymentClient;
+    private final UserClient userClient;
     private final RollbackService rollbackService;
 
 
     // 타임세일상품 재고 확인 및 차감 요청
-    public void checkAndDeductTimeSaleProduct(List<String> deductedTimeSales, String timeSaleProductId) {
-        if (timeSaleProductId != null) {
-            timeSaleProductClient.checkAndDeductTimeSaleProduct(timeSaleProductId);
-            deductedTimeSales.add(timeSaleProductId);
+    public void checkAndDeductTimeSaleProduct(OrderRollbackContext context, String timeSaleProductId) {
+        try {
+            if (timeSaleProductId != null) {
+                timeSaleProductClient.checkAndDeductTimeSaleProduct(timeSaleProductId);
+                context.addDeductedTimeSale(timeSaleProductId);
+            }
+        } catch (FeignException e) {
+            log.error("[TimeSale-Service FeignException]: Deduct TimeSale Product Request Error");
+            rollbackService.createOrderItemsRollbackTransaction(context);
+            throw new BusinessException(HttpStatus.CONFLICT, e.getMessage(), "5006");
         }
     }
 
     // 상품 재고 확인 및 차감 요청
-    public void checkAndDeductStock(List<String> deductedProducts, String productId, int quantity) {
-        productClient.checkAndDeductStock(new ProductDeductRequestDto(productId, quantity));
-        deductedProducts.add(productId);
+    public void checkAndDeductStock(OrderRollbackContext context, String productId, int quantity) {
+        try {
+            productClient.checkAndDeductStock(new ProductDeductRequestDto(productId, quantity));
+            context.addDeductedProduct(productId);
+        } catch (FeignException e) {
+            log.error("[Brand(Product)-Service FeignException]: DeductStock Request Error");
+            rollbackService.createOrderItemsRollbackTransaction(context);
+            throw new BusinessException(HttpStatus.CONFLICT, e.getMessage(), "5007");
+        }
     }
 
     // 쿠폰 확인 및 상태변경 요청
-    public CouponInfoDto checkAndUseCoupon(List<String> usedCoupons, String couponIssuedId, String userId) {
+    public CouponInfoDto checkAndUseCoupon(OrderRollbackContext context, String couponIssuedId, String userId) {
         String saleType = null;
         Integer discountValue = null;
-        if (couponIssuedId != null) {
-            String couponId = couponIssueClient.useCouponIssue(couponIssuedId, userId).data().couponId();
-            usedCoupons.add(couponIssuedId);
 
-            CouponResponseDto couponInfo = couponIssueClient.getCouponType(couponId).data();
-            saleType = couponInfo.couponSaleType();
-            discountValue = checkCouponSaleType(couponInfo);
+        try {
+            if (couponIssuedId != null) {
+                String couponId = couponIssueClient.useCouponIssue(couponIssuedId, userId).data().couponId();
+                context.addUsedCoupon(couponIssuedId);
+
+                CouponResponseDto couponInfo = couponIssueClient.getCouponType(couponId).data();
+                saleType = couponInfo.couponSaleType();
+                discountValue = checkCouponSaleType(couponInfo);
+            }
+        } catch (FeignException e) {
+            log.error("[Coupon-Service FeignException]: UseCoupon Request Error");
+            rollbackService.createOrderItemsRollbackTransaction(context);
+            throw new BusinessException(HttpStatus.CONFLICT, e.getMessage(), "5008");
         }
         return CouponInfoDto.of(saleType, discountValue);
+    }
+
+    // 적립금 확인 및 차감 요청
+    public void checkAndUsePoint(OrderRollbackContext context, Order order, int point, String userId) {
+        try {
+            if (point > 0) {
+                PointModifyRequestDto pointRequestDto = new PointModifyRequestDto(userId, point);
+                userClient.checkAndUseRewardPoint(pointRequestDto);
+                order.usePoint(point);
+            }
+        } catch (FeignException e) {
+            log.error("[User(Point)-Service FeignException]: UsePoint Request Error");
+            rollbackService.createOrderItemsRollbackTransaction(context);
+            throw new BusinessException(HttpStatus.CONFLICT, e.getMessage(), "5008");
+        }
     }
 
     // 결제 승인 요청 - 간편결제
@@ -69,7 +107,7 @@ public class ProcessService {
             String paymentId = paymentClient.requestEasyPay(paymentRequestDto).data().paymentId();
             order.setPaymentIdAndType(paymentId, PaymentType.TOSS_PAYMENTS);
         } catch (FeignException e) {
-            // TODO -> 주문 취소 처리 - 보상 트랜잭션(롤백)
+            log.error("[Payment-Service FeignException]: EasyPay Request Error");
             rollbackService.cancelOrderItemsRollback(order.getOrderItems());
             throw new BusinessException(ExceptionMessage.ORDER_PAYMENT_FAILED);
         }
@@ -82,7 +120,7 @@ public class ProcessService {
             String paymentId = paymentClient.requestTossPayment(paymentRequestDto).data().paymentId();
             order.setPaymentIdAndType(paymentId, PaymentType.TOSS_PAYMENTS);
         } catch (FeignException e) {
-            // TODO -> 주문 취소 처리 - 보상 트랜잭션(롤백)
+            log.error("[Payment-Service FeignException]: TossPay Request Error");
             rollbackService.cancelOrderItemsRollback(order.getOrderItems());
             throw new BusinessException(ExceptionMessage.ORDER_PAYMENT_FAILED);
         }
@@ -116,6 +154,4 @@ public class ProcessService {
             requestDto.paymentKeyId(),
             requestDto.amount().longValue());
     }
-
-
 }

--- a/service/order/order-core/src/main/java/radiata/service/order/core/service/ProcessService.java
+++ b/service/order/order-core/src/main/java/radiata/service/order/core/service/ProcessService.java
@@ -1,0 +1,58 @@
+package radiata.service.order.core.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import radiata.common.domain.brand.request.ProductDeductRequestDto;
+import radiata.common.domain.coupon.dto.response.CouponResponseDto;
+import radiata.common.domain.order.dto.response.CouponInfoDto;
+import radiata.service.order.core.service.client.CouponIssueClient;
+import radiata.service.order.core.service.client.ProductClient;
+import radiata.service.order.core.service.client.TimeSaleProductClient;
+
+@Service
+@RequiredArgsConstructor
+public class ProcessService {
+
+    private final TimeSaleProductClient timeSaleProductClient;
+    private final ProductClient productClient;
+    private final CouponIssueClient couponIssueClient;
+
+
+    // 타임세일상품 재고 확인 및 차감 요청
+    public void checkAndDeductTimeSaleProduct(List<String> deductedTimeSales, String timeSaleProductId) {
+        if (timeSaleProductId != null) {
+            timeSaleProductClient.checkAndDeductTimeSaleProduct(timeSaleProductId);
+            deductedTimeSales.add(timeSaleProductId);
+        }
+    }
+
+    // 상품 재고 확인 및 차감 요청
+    public void checkAndDeductStock(List<String> deductedProducts, String productId, int quantity) {
+        productClient.checkAndDeductStock(new ProductDeductRequestDto(productId, quantity));
+        deductedProducts.add(productId);
+    }
+
+    // 쿠폰 확인 및 상태변경 요청
+    public CouponInfoDto checkAndUseCoupon(List<String> usedCoupons, String couponIssuedId, String userId) {
+        String saleType = null;
+        Integer discountValue = null;
+        if (couponIssuedId != null) {
+            String couponId = couponIssueClient.useCouponIssue(couponIssuedId, userId).data().couponId();
+            usedCoupons.add(couponIssuedId);
+
+            CouponResponseDto couponInfo = couponIssueClient.getCouponType(couponId).data();
+            saleType = couponInfo.couponSaleType();
+            discountValue = checkCouponSaleType(couponInfo);
+        }
+        return CouponInfoDto.of(saleType, discountValue);
+    }
+
+    private int checkCouponSaleType(CouponResponseDto couponInfo) {
+        // TODO - CouponType enum 으로 수정
+        if (couponInfo.couponSaleType().equals("AMOUNT")) {
+            return couponInfo.discountAmount();
+        }
+        return couponInfo.discountRate();
+    }
+}

--- a/service/order/order-core/src/main/java/radiata/service/order/core/service/ProcessService.java
+++ b/service/order/order-core/src/main/java/radiata/service/order/core/service/ProcessService.java
@@ -154,7 +154,7 @@ public class ProcessService {
         return new TossPaymentCreateRequestDto(
             orderId,
             userId,
-            requestDto.paymentKeyId(),
+            requestDto.paymentKey(),
             requestDto.amount().longValue());
     }
 

--- a/service/order/order-core/src/main/java/radiata/service/order/core/service/RollbackService.java
+++ b/service/order/order-core/src/main/java/radiata/service/order/core/service/RollbackService.java
@@ -6,7 +6,11 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
+import radiata.common.domain.order.dto.request.AddPointRequestDto;
+import radiata.common.domain.order.dto.request.AddStockRequestDto;
 import radiata.common.domain.order.dto.response.StockInfoDto;
+import radiata.service.order.core.domain.model.constant.OrderStatus;
+import radiata.service.order.core.domain.model.entity.Order;
 import radiata.service.order.core.domain.model.entity.OrderItem;
 import radiata.service.order.core.service.context.OrderRollbackContext;
 
@@ -15,16 +19,18 @@ import radiata.service.order.core.service.context.OrderRollbackContext;
 @RequiredArgsConstructor
 public class RollbackService {
 
-    private final KafkaTemplate<String, String> paymentKafkaTemplate;
+    private final KafkaTemplate<String, String> cancelRequestKafkaTemplate;
+    private final KafkaTemplate<String, AddStockRequestDto> addStockKafkaTemplate;
+    private final KafkaTemplate<String, AddPointRequestDto> addPointKafkaTemplate;
 
     // 보상 트랜잭션 - 타임 세일 상품 재고
     private void rollbackTimeSaleStock(List<StockInfoDto> deductedTimeSaleStocks) {
         try {
             // 타임세일 상품 재고 증감 요청
             deductedTimeSaleStocks.forEach(timeSaleProduct -> {
-                // TODO - kafka 를 이용한 비동기 처리
-                System.out.println("timeSaleProductId = " + timeSaleProduct.id());
-                System.out.println("timeSale quantity = " + timeSaleProduct.quantity());
+                AddStockRequestDto requestDto = new AddStockRequestDto(timeSaleProduct.id(),
+                    timeSaleProduct.quantity());
+                addStockKafkaTemplate.send("timesale.add-stock", requestDto);
             });
         } catch (RuntimeException e) {
             log.error(" [Rollback Error]: TimeSale-Service ");
@@ -36,9 +42,8 @@ public class RollbackService {
         try {
             // 상품 재고 증감 요청
             deductedProductStocks.forEach(product -> {
-                // TODO - kafka 를 이용한 비동기 처리
-                System.out.println("productId = " + product.id());
-                System.out.println("product quantity = " + product.quantity());
+                AddStockRequestDto requestDto = new AddStockRequestDto(product.id(), product.quantity());
+                addStockKafkaTemplate.send("product.add-stock", requestDto);
             });
         } catch (RuntimeException e) {
             log.error(" [Rollback Error]: Product-Service ");
@@ -50,8 +55,7 @@ public class RollbackService {
         try {
             // 쿠폰 상태 변경 요청(USED -> ISSUED)
             usedCoupons.forEach(usedCouponId -> {
-                // TODO - kafka 를 이용한 비동기 처리
-                System.out.println("usedCouponId = " + usedCouponId);
+                cancelRequestKafkaTemplate.send("coupon.rollback-status", usedCouponId);
             });
         } catch (RuntimeException e) {
             log.error(" [Rollback Error]: Coupon-Service ");
@@ -59,20 +63,21 @@ public class RollbackService {
     }
 
     // 보상 트랜잭션 - 적립금
-    private void rollbackRewardPoint(String userId) {
+    private void rollbackRewardPoint(String userId, Integer point) {
         try {
             // 적립금 증감 요청
-            // TODO - kafka 를 이용한 비동기 처리
+            AddPointRequestDto requestDto = new AddPointRequestDto(userId, point);
+            addPointKafkaTemplate.send("user.add-point", requestDto);
         } catch (RuntimeException e) {
             log.error(" [Rollback Error]: User(Point)-Service ");
         }
     }
 
+    // 보상 트랜잭션 - 결제 취소
     private void rollbackPaymentAmount(String paymentId) {
         try {
             // 결제 취소 요청 - (== 환불)
-            // TODO - userId 필요할까?
-            paymentKafkaTemplate.send("paymentRollback", paymentId);
+            cancelRequestKafkaTemplate.send("payment.cancel", paymentId);
         } catch (RuntimeException e) {
             log.error(" [Rollback Error]: Payment-Service ");
         }
@@ -82,26 +87,58 @@ public class RollbackService {
     // 주문 등록 - 보상 트랜잭션
     public void createOrderItemsRollbackTransaction(OrderRollbackContext context) {
 
-        List<StockInfoDto> test = context.getDeductedProducts();
         rollbackTimeSaleStock(context.getDeductedTimeSales());
         rollbackProductStock(context.getDeductedProducts());
         rollbackCoupons(context.getUsedCoupons());
     }
 
     // 주문 취소 - 보상 트랜잭션
-    public void cancelOrderItemsRollback(Set<OrderItem> orderItems) {
+    public void cancelOrderItemsRollback(Order order) {
 
-        // 타임세일 재고 롤백
-        // 상품 재고 롤백
-        // 쿠폰 상태 롤백
-        // 적립금?
+        OrderRollbackContext rollbackContext = collectOrderItemInfo(order.getOrderItems());
+
+        // TODO - 타임세일 시간 끝나면 복구 안해도 되지않나?
+        rollbackTimeSaleStock(rollbackContext.getDeductedTimeSales());
+        rollbackProductStock(rollbackContext.getDeductedProducts());
+        rollbackCoupons(rollbackContext.getUsedCoupons());
+
+        checkUsedPointAndReward(order.getUserId(), order.getUsedPoint());
+        checkPaymentStatusAndRollback(order.getStatus(), order.getPaymentId());
     }
 
-    public void refundPaymentAmountRollback(Set<OrderItem> orderItems, String paymentId) {
-        rollbackPaymentAmount(paymentId);
-        // 타임세일 재고 롤백
-        // 상품 재고 롤백
-        // 쿠폰 상태 롤백
-        // 적립금?
+    // 환불
+    public void refundRollback(Order order) {
+
+        OrderRollbackContext rollbackContext = collectOrderItemInfo(order.getOrderItems());
+
+        rollbackPaymentAmount(order.getPaymentId());
+        // TODO - 타임세일 시간 끝나면 복구 안해도 되지않나?
+        rollbackTimeSaleStock(rollbackContext.getDeductedTimeSales());
+        rollbackProductStock(rollbackContext.getDeductedProducts());
+    }
+
+    private void checkPaymentStatusAndRollback(OrderStatus status, String paymentId) {
+
+        if (status.equals(OrderStatus.PAYMENT_COMPLETED) || status.equals(OrderStatus.PAYMENT_CANCEL_REQUESTED)) {
+            rollbackPaymentAmount(paymentId);
+        }
+    }
+
+    private void checkUsedPointAndReward(String userId, Integer usedPoint) {
+        if (usedPoint != null) {
+            rollbackRewardPoint(userId, usedPoint);
+        }
+    }
+
+    private OrderRollbackContext collectOrderItemInfo(Set<OrderItem> orderItems) {
+        OrderRollbackContext rollbackContext = new OrderRollbackContext();
+
+        for (OrderItem orderItem : orderItems) {
+            int quantity = orderItem.getQuantity();
+            rollbackContext.addDeductedTimeSale(orderItem.getTimeSaleProductId(), quantity);
+            rollbackContext.addDeductedProduct(orderItem.getProductId(), quantity);
+            rollbackContext.addUsedCoupon(orderItem.getCouponIssuedId());
+        }
+        return rollbackContext;
     }
 }

--- a/service/order/order-core/src/main/java/radiata/service/order/core/service/RollbackService.java
+++ b/service/order/order-core/src/main/java/radiata/service/order/core/service/RollbackService.java
@@ -1,0 +1,88 @@
+package radiata.service.order.core.service;
+
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import radiata.service.order.core.domain.model.entity.OrderItem;
+
+@Service
+@Slf4j(topic = "Rollback-Service")
+@RequiredArgsConstructor
+public class RollbackService {
+
+    // 보상 트랜잭션 - 타임 세일 상품 재고
+    private void rollbackTimeSaleStock(List<String> deductedTimeSaleStocks) {
+        try {
+            // 타임세일 상품 재고 증감 요청
+            deductedTimeSaleStocks.forEach(timeSaleProduct -> {
+                // TODO - kafka 를 이용한 비동기 처리
+            });
+        } catch (RuntimeException e) {
+            log.info(" [Rollback Error]: TimeSale-Service ");
+        }
+    }
+
+    // 보상 트랜잭션 - 상품 재고
+    private void rollbackProductStock(List<String> deductedProductStocks) {
+        try {
+            // 상품 재고 증감 요청
+            deductedProductStocks.forEach(product -> {
+                // TODO - kafka 를 이용한 비동기 처리
+            });
+        } catch (RuntimeException e) {
+            log.info(" [Rollback Error]: Product-Service ");
+        }
+    }
+
+    // 보상 트랜잭션 - 쿠폰 상태
+    private void rollbackCoupons(List<String> usedCoupons) {
+        try {
+            // 쿠폰 상태 변경 요청(USED -> ISSUED)
+            usedCoupons.forEach(usedCouponId -> {
+                // TODO - kafka 를 이용한 비동기 처리
+            });
+        } catch (RuntimeException e) {
+            log.info(" [Rollback Error]: Coupon-Service ");
+        }
+    }
+
+    // 보상 트랜잭션 - 적립금
+    private void rollbackRewardPoint(String userId) {
+        try {
+            // 적립금 증감 요청
+            // TODO - kafka 를 이용한 비동기 처리
+        } catch (RuntimeException e) {
+            log.info(" [Rollback Error]: User(Point)-Service ");
+        }
+    }
+
+    private void rollbackPaymentAmount(String paymentId) {
+        try {
+            // 결제 취소 요청 - (== 환불)
+
+        } catch (RuntimeException e) {
+            log.info(" [Rollback Error]: Payment-Service ");
+        }
+    }
+
+
+    // 주문 등록 - 보상 트랜잭션
+    public void createOrderItemsRollbackTransaction(List<String> deductedTimeSales, List<String> deductedProducts,
+        List<String> usedCoupons) {
+
+        rollbackTimeSaleStock(deductedTimeSales);
+        rollbackProductStock(deductedProducts);
+        rollbackCoupons(usedCoupons);
+    }
+
+    // 주문 취소 - 보상 트랜잭션
+    public void cancelOrderItemsRollback(Set<OrderItem> orderItems, String paymentId) {
+        rollbackPaymentAmount(paymentId);
+        // 타임세일 재고 롤백
+        // 상품 재고 롤백
+        // 쿠폰 상태 롤백
+        // 적립금?
+    }
+}

--- a/service/order/order-core/src/main/java/radiata/service/order/core/service/RollbackService.java
+++ b/service/order/order-core/src/main/java/radiata/service/order/core/service/RollbackService.java
@@ -4,7 +4,9 @@ import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
+import radiata.common.domain.order.dto.response.StockInfoDto;
 import radiata.service.order.core.domain.model.entity.OrderItem;
 import radiata.service.order.core.service.context.OrderRollbackContext;
 
@@ -13,13 +15,16 @@ import radiata.service.order.core.service.context.OrderRollbackContext;
 @RequiredArgsConstructor
 public class RollbackService {
 
+    private final KafkaTemplate<String, String> paymentKafkaTemplate;
+
     // 보상 트랜잭션 - 타임 세일 상품 재고
-    private void rollbackTimeSaleStock(List<String> deductedTimeSaleStocks) {
+    private void rollbackTimeSaleStock(List<StockInfoDto> deductedTimeSaleStocks) {
         try {
             // 타임세일 상품 재고 증감 요청
             deductedTimeSaleStocks.forEach(timeSaleProduct -> {
                 // TODO - kafka 를 이용한 비동기 처리
-                System.out.println("timeSaleProductId = " + timeSaleProduct);
+                System.out.println("timeSaleProductId = " + timeSaleProduct.id());
+                System.out.println("timeSale quantity = " + timeSaleProduct.quantity());
             });
         } catch (RuntimeException e) {
             log.error(" [Rollback Error]: TimeSale-Service ");
@@ -27,12 +32,13 @@ public class RollbackService {
     }
 
     // 보상 트랜잭션 - 상품 재고
-    private void rollbackProductStock(List<String> deductedProductStocks) {
+    private void rollbackProductStock(List<StockInfoDto> deductedProductStocks) {
         try {
             // 상품 재고 증감 요청
             deductedProductStocks.forEach(product -> {
                 // TODO - kafka 를 이용한 비동기 처리
-                System.out.println("productId = " + product);
+                System.out.println("productId = " + product.id());
+                System.out.println("product quantity = " + product.quantity());
             });
         } catch (RuntimeException e) {
             log.error(" [Rollback Error]: Product-Service ");
@@ -65,7 +71,8 @@ public class RollbackService {
     private void rollbackPaymentAmount(String paymentId) {
         try {
             // 결제 취소 요청 - (== 환불)
-
+            // TODO - userId 필요할까?
+            paymentKafkaTemplate.send("paymentRollback", paymentId);
         } catch (RuntimeException e) {
             log.error(" [Rollback Error]: Payment-Service ");
         }
@@ -75,6 +82,7 @@ public class RollbackService {
     // 주문 등록 - 보상 트랜잭션
     public void createOrderItemsRollbackTransaction(OrderRollbackContext context) {
 
+        List<StockInfoDto> test = context.getDeductedProducts();
         rollbackTimeSaleStock(context.getDeductedTimeSales());
         rollbackProductStock(context.getDeductedProducts());
         rollbackCoupons(context.getUsedCoupons());

--- a/service/order/order-core/src/main/java/radiata/service/order/core/service/RollbackService.java
+++ b/service/order/order-core/src/main/java/radiata/service/order/core/service/RollbackService.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import radiata.service.order.core.domain.model.entity.OrderItem;
+import radiata.service.order.core.service.context.OrderRollbackContext;
 
 @Service
 @Slf4j(topic = "Rollback-Service")
@@ -18,9 +19,10 @@ public class RollbackService {
             // 타임세일 상품 재고 증감 요청
             deductedTimeSaleStocks.forEach(timeSaleProduct -> {
                 // TODO - kafka 를 이용한 비동기 처리
+                System.out.println("timeSaleProductId = " + timeSaleProduct);
             });
         } catch (RuntimeException e) {
-            log.info(" [Rollback Error]: TimeSale-Service ");
+            log.error(" [Rollback Error]: TimeSale-Service ");
         }
     }
 
@@ -30,9 +32,10 @@ public class RollbackService {
             // 상품 재고 증감 요청
             deductedProductStocks.forEach(product -> {
                 // TODO - kafka 를 이용한 비동기 처리
+                System.out.println("productId = " + product);
             });
         } catch (RuntimeException e) {
-            log.info(" [Rollback Error]: Product-Service ");
+            log.error(" [Rollback Error]: Product-Service ");
         }
     }
 
@@ -42,9 +45,10 @@ public class RollbackService {
             // 쿠폰 상태 변경 요청(USED -> ISSUED)
             usedCoupons.forEach(usedCouponId -> {
                 // TODO - kafka 를 이용한 비동기 처리
+                System.out.println("usedCouponId = " + usedCouponId);
             });
         } catch (RuntimeException e) {
-            log.info(" [Rollback Error]: Coupon-Service ");
+            log.error(" [Rollback Error]: Coupon-Service ");
         }
     }
 
@@ -54,7 +58,7 @@ public class RollbackService {
             // 적립금 증감 요청
             // TODO - kafka 를 이용한 비동기 처리
         } catch (RuntimeException e) {
-            log.info(" [Rollback Error]: User(Point)-Service ");
+            log.error(" [Rollback Error]: User(Point)-Service ");
         }
     }
 
@@ -63,23 +67,22 @@ public class RollbackService {
             // 결제 취소 요청 - (== 환불)
 
         } catch (RuntimeException e) {
-            log.info(" [Rollback Error]: Payment-Service ");
+            log.error(" [Rollback Error]: Payment-Service ");
         }
     }
 
 
     // 주문 등록 - 보상 트랜잭션
-    public void createOrderItemsRollbackTransaction(List<String> deductedTimeSales, List<String> deductedProducts,
-        List<String> usedCoupons) {
+    public void createOrderItemsRollbackTransaction(OrderRollbackContext context) {
 
-        rollbackTimeSaleStock(deductedTimeSales);
-        rollbackProductStock(deductedProducts);
-        rollbackCoupons(usedCoupons);
+        rollbackTimeSaleStock(context.getDeductedTimeSales());
+        rollbackProductStock(context.getDeductedProducts());
+        rollbackCoupons(context.getUsedCoupons());
     }
 
     // 주문 취소 - 보상 트랜잭션
     public void cancelOrderItemsRollback(Set<OrderItem> orderItems) {
-        
+
         // 타임세일 재고 롤백
         // 상품 재고 롤백
         // 쿠폰 상태 롤백

--- a/service/order/order-core/src/main/java/radiata/service/order/core/service/RollbackService.java
+++ b/service/order/order-core/src/main/java/radiata/service/order/core/service/RollbackService.java
@@ -78,7 +78,15 @@ public class RollbackService {
     }
 
     // 주문 취소 - 보상 트랜잭션
-    public void cancelOrderItemsRollback(Set<OrderItem> orderItems, String paymentId) {
+    public void cancelOrderItemsRollback(Set<OrderItem> orderItems) {
+        
+        // 타임세일 재고 롤백
+        // 상품 재고 롤백
+        // 쿠폰 상태 롤백
+        // 적립금?
+    }
+
+    public void refundPaymentAmountRollback(Set<OrderItem> orderItems, String paymentId) {
         rollbackPaymentAmount(paymentId);
         // 타임세일 재고 롤백
         // 상품 재고 롤백

--- a/service/order/order-core/src/main/java/radiata/service/order/core/service/client/PaymentClient.java
+++ b/service/order/order-core/src/main/java/radiata/service/order/core/service/client/PaymentClient.java
@@ -3,6 +3,7 @@ package radiata.service.order.core.service.client;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import radiata.common.domain.payment.dto.request.EasyPayCreateRequestDto;
 import radiata.common.domain.payment.dto.request.TossPaymentCreateRequestDto;
 import radiata.common.domain.payment.dto.response.PaymentCreateResponseDto;
 import radiata.common.response.SuccessResponse;
@@ -11,5 +12,8 @@ import radiata.common.response.SuccessResponse;
 public interface PaymentClient {
 
     @PostMapping("/payments/toss")
-    SuccessResponse<PaymentCreateResponseDto> requestTossPayment(@RequestBody TossPaymentCreateRequestDto request);
+    SuccessResponse<PaymentCreateResponseDto> requestTossPayment(@RequestBody TossPaymentCreateRequestDto requestDto);
+
+    @PostMapping("/payments/easypay")
+    SuccessResponse<PaymentCreateResponseDto> requestEasyPay(@RequestBody EasyPayCreateRequestDto requestDto);
 }

--- a/service/order/order-core/src/main/java/radiata/service/order/core/service/client/ProductClient.java
+++ b/service/order/order-core/src/main/java/radiata/service/order/core/service/client/ProductClient.java
@@ -1,7 +1,7 @@
 package radiata.service.order.core.service.client;
 
 import org.springframework.cloud.openfeign.FeignClient;
-import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import radiata.common.domain.brand.request.ProductDeductRequestDto;
 import radiata.common.response.SuccessResponse;
@@ -9,7 +9,7 @@ import radiata.common.response.SuccessResponse;
 @FeignClient(name = "brand-service")
 public interface ProductClient {
 
-    @PostMapping("/goods/deduct")
+    @PatchMapping("/products/deduct")
     SuccessResponse<String> checkAndDeductStock(@RequestBody ProductDeductRequestDto requestDto);
 
 }

--- a/service/order/order-core/src/main/java/radiata/service/order/core/service/client/TimeSaleProductClient.java
+++ b/service/order/order-core/src/main/java/radiata/service/order/core/service/client/TimeSaleProductClient.java
@@ -1,15 +1,13 @@
 package radiata.service.order.core.service.client;
 
 import org.springframework.cloud.openfeign.FeignClient;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import radiata.common.response.CommonResponse;
+import radiata.common.response.SuccessResponse;
 
 @FeignClient(name = "timesale-service")
 public interface TimeSaleProductClient {
 
-    // TODO - 수정 가능성 O (미확정)
-    @GetMapping("/timesale-products/{timeSaleProductId}")
-    ResponseEntity<? extends CommonResponse> checkAndDeductTimeSaleProduct(@PathVariable String timeSaleProductId);
+    @PatchMapping("/timesale-products/{timeSaleProductId}")
+    SuccessResponse<String> checkAndDeductTimeSaleProduct(@PathVariable String timeSaleProductId);
 }

--- a/service/order/order-core/src/main/java/radiata/service/order/core/service/client/UserClient.java
+++ b/service/order/order-core/src/main/java/radiata/service/order/core/service/client/UserClient.java
@@ -1,14 +1,14 @@
 package radiata.service.order.core.service.client;
 
 import org.springframework.cloud.openfeign.FeignClient;
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import radiata.common.domain.user.dto.request.PointModifyRequestDto;
-import radiata.common.response.CommonResponse;
+import radiata.common.response.SuccessResponse;
 
 @FeignClient(name = "user-service")
 public interface UserClient {
 
-    @GetMapping("/users/points/deduct")
-    CommonResponse checkAndUseRewardPoint(@RequestBody PointModifyRequestDto requestDto);
+    @PatchMapping("/users/points/deduct")
+    SuccessResponse<Void> checkAndUseRewardPoint(@RequestBody PointModifyRequestDto requestDto);
 }

--- a/service/order/order-core/src/main/java/radiata/service/order/core/service/context/OrderRollbackContext.java
+++ b/service/order/order-core/src/main/java/radiata/service/order/core/service/context/OrderRollbackContext.java
@@ -3,21 +3,22 @@ package radiata.service.order.core.service.context;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.Getter;
+import radiata.common.domain.order.dto.response.StockInfoDto;
 
 @Getter
 public class OrderRollbackContext {
 
     // 롤백에 필요한 리스트
-    private List<String> deductedTimeSales = new ArrayList<>();
-    private List<String> deductedProducts = new ArrayList<>();
+    private List<StockInfoDto> deductedTimeSales = new ArrayList<>();
+    private List<StockInfoDto> deductedProducts = new ArrayList<>();
     private List<String> usedCoupons = new ArrayList<>();
 
-    public void addDeductedTimeSale(String timeSaleProductId) {
-        deductedTimeSales.add(timeSaleProductId);
+    public void addDeductedTimeSale(String timeSaleProductId, int quantity) {
+        deductedTimeSales.add(new StockInfoDto(timeSaleProductId, quantity));
     }
 
-    public void addDeductedProduct(String productId) {
-        deductedProducts.add(productId);
+    public void addDeductedProduct(String productId, int quantity) {
+        deductedProducts.add(new StockInfoDto(productId, quantity));
     }
 
     public void addUsedCoupon(String couponIssuedId) {

--- a/service/order/order-core/src/main/java/radiata/service/order/core/service/context/OrderRollbackContext.java
+++ b/service/order/order-core/src/main/java/radiata/service/order/core/service/context/OrderRollbackContext.java
@@ -1,0 +1,26 @@
+package radiata.service.order.core.service.context;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class OrderRollbackContext {
+
+    // 롤백에 필요한 리스트
+    private List<String> deductedTimeSales = new ArrayList<>();
+    private List<String> deductedProducts = new ArrayList<>();
+    private List<String> usedCoupons = new ArrayList<>();
+
+    public void addDeductedTimeSale(String timeSaleProductId) {
+        deductedTimeSales.add(timeSaleProductId);
+    }
+
+    public void addDeductedProduct(String productId) {
+        deductedProducts.add(productId);
+    }
+
+    public void addUsedCoupon(String couponIssuedId) {
+        usedCoupons.add(couponIssuedId);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> - closed: #80 

## 📝작업 내용

> 간편 결제 & 토스페이 결제 승인요청 기능으로 분리하고
결제 서비스에 Feign 요청 보내는 걸로 설정했습니다!
++ 서비스를 분리해 보았읍니다..!
이전보다는 깔끔해진거 같긴한데 코멘트 한번씩 부탁드립니다!

Kafka 설정 추가했습니다!. 
이상한 점 있으면 말씀해주세요! 

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 서비스 분리를 하면서 ProcessService쪽에서 던지는 BusinessException에서 잡은 FeignException의 에러코드와 메시지를 잡고 싶은데 방법이 있을까요?
이걸 메서드로 추가해볼까 햇는데 시행한다면
ErrorResponse 클래스에 파싱하는 메서드를 추가하는게 좋을까요?
>